### PR TITLE
Changing alts & titles on images to be helpful

### DIFF
--- a/modifiers.html
+++ b/modifiers.html
@@ -129,7 +129,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 60%;">
-                <img src="assets/images/aquaphilic-240x141.png" alt="Modifiers" title="">
+                <img src="assets/images/aquaphilic-240x141.png" alt="4 Prismarine Shards on corners, a Heart of the Sea on the middle and 4 Nautilus Shells on the 4 empty slots." title="Can be crafted through a crafting table.">
             </div>
 
             <div class="media-content">
@@ -155,7 +155,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 60%;">
-                <img src="assets/images/autosmelt-251x142.jpg" alt="Modifiers" title="">
+                <img src="assets/images/autosmelt-251x142.jpg" alt="A Blaze Rod surrounded by 8 Furnaces." title="Can be crafted through a crafting table.">
             </div>
 
             <div class="media-content">
@@ -181,7 +181,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 20%;">
-                <img src="assets/images/beheading-150x150.png" alt="Modifiers" title="">
+                <img src="assets/images/beheading-150x150.png" alt="A Wither Skull." title="">
             </div>
 
             <div class="media-content">
@@ -207,7 +207,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 60%;">
-                <img src="assets/images/directing-250x135.png" alt="Modifiers" title="">
+                <img src="assets/images/directing-250x135.png" alt="4 Ender Pearls on corner, an Iron Block on the middle and 4 Compasses on the 4 empty slots." title="Can be crafted through a crafting table.">
             </div>
 
             <div class="media-content">
@@ -233,7 +233,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 60%;">
-                <img src="assets/images/ender-245x138.jpg" alt="Modifiers" title="">
+                <img src="assets/images/ender-245x138.jpg" alt="An Eye of Ender surrounded by 8 Ender Pearls." title="Can be crafted through a crafting table.">
             </div>
 
             <div class="media-content">
@@ -259,7 +259,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 20%;">
-                <img src="assets/images/experienced-150x150.png" alt="Modifiers" title="">
+                <img src="assets/images/experienced-150x150.png" alt="A Bottle O' Enchanting." title="">
             </div>
 
             <div class="media-content">
@@ -285,7 +285,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 25%;">
-                <img src="assets/images/extra-modifier-150x150.png" alt="Modifiers" title="">
+                <img src="assets/images/extra-modifier-150x150.png" alt="A Nether Star." title="">
             </div>
 
             <div class="media-content">
@@ -311,7 +311,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 20%;">
-                <img src="assets/images/fiery-150x150.png" alt="Modifiers" title="">
+                <img src="assets/images/fiery-150x150.png" alt="A Blaze Rod." title="">
             </div>
 
             <div class="media-content">
@@ -337,7 +337,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 60%;">
-                <img src="assets/images/freezing-241x135.png" alt="Modifiers" title="">
+                <img src="assets/images/freezing-241x135.png" alt="A Diamond surrounded by 8 Blue Ices." title="Can be crafted through a crafting table.">
             </div>
 
             <div class="media-content">
@@ -363,7 +363,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 60%;">
-                <img src="assets/images/glowing-244x140.jpg" alt="Modifiers" title="">
+                <img src="assets/images/glowing-244x140.jpg" alt="An Eye of Ender surrounded by 8 Glowstone Dusts." title="Can be crafted through a crafting table.">
             </div>
 
             <div class="media-content">
@@ -389,7 +389,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 60%;">
-                <img src="assets/images/haste-247x138.jpg" alt="Modifiers" title="">
+                <img src="assets/images/haste-247x138.jpg" alt="9 Redstone Blocks." title="Can be crafted through a crafting table.">
             </div>
 
             <div class="media-content">
@@ -415,7 +415,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 20%;">
-                <img src="assets/images/infinity-150x150.png" alt="Modifiers" title="">
+                <img src="assets/images/infinity-150x150.png" alt="An Arrow." title="">
             </div>
 
             <div class="media-content">
@@ -441,7 +441,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 20%;">
-                <img src="assets/images/knockback-150x150.png" alt="Modifiers" title="">
+                <img src="assets/images/knockback-150x150.png" alt="A TNT block." title="">
             </div>
 
             <div class="media-content">
@@ -467,7 +467,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 60%;">
-                <img src="assets/images/lifesteal-253x144.png" alt="Modifiers" title="">
+                <img src="assets/images/lifesteal-253x144.png" alt="4 Soul Sands on the corner, a Netherrack on the middle and 4 Rotten Flesh on the 4 empty slots." title="Can be crafted through a crafting table.">
             </div>
 
             <div class="media-content">
@@ -493,7 +493,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 20%;">
-                <img src="assets/images/lightweight-150x150.png" alt="Modifiers" title="">
+                <img src="assets/images/lightweight-150x150.png" alt="A Feather." title="">
             </div>
 
             <div class="media-content">
@@ -519,7 +519,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 60%;">
-                <img src="assets/images/luck-248x143.jpg" alt="Modifiers" title="">
+                <img src="assets/images/luck-248x143.jpg" alt="9 Blocks of Lapis Lazuli." title="Can be crafted through a crafting table.">
             </div>
 
             <div class="media-content">
@@ -545,7 +545,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 20%;">
-                <img src="assets/images/magmablock.gif" alt="Modifiers" title="">
+                <img src="assets/images/magmablock.gif" alt="A Magma Block." title="">
             </div>
 
             <div class="media-content">
@@ -571,7 +571,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 20%;">
-                <img src="assets/images/poisonous-150x150.png" alt="Modifiers" title="">
+                <img src="assets/images/poisonous-150x150.png" alt="A Rotten Flesh." title="">
             </div>
 
             <div class="media-content">
@@ -597,7 +597,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 20%;">
-                <img src="assets/images/power-150x150.png" alt="Modifiers" title="">
+                <img src="assets/images/power-150x150.png" alt="An Emerald." title="">
             </div>
 
             <div class="media-content">
@@ -623,7 +623,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 20%;">
-                <img src="assets/images/propelling-150x150.png" alt="Modifiers" title="">
+                <img src="assets/images/propelling-150x150.png" alt="A Firework Star." title="">
             </div>
 
             <div class="media-content">
@@ -649,7 +649,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 60%;">
-                <img src="assets/images/protecting-243x135.png" alt="Modifiers" title="">
+                <img src="assets/images/protecting-243x135.png" alt="4 Diamonds on corner, an Obsidian on the middle and 4 Iron Ingots on the 4 empty slots." title="Can be crafted through a crafting table.">
             </div>
 
             <div class="media-content">
@@ -675,7 +675,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 60%;">
-                <img src="assets/images/reinforced-236x137.jpg" alt="Modifiers" title="">
+                <img src="assets/images/reinforced-236x137.jpg" alt="9 Obsidian blocks." title="Can be crafted through a crafting table.">
             </div>
 
             <div class="media-content">
@@ -702,7 +702,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 20%;">
-                <img src="assets/images/selfrepair-260x260.png" alt="Modifiers" title="">
+                <img src="assets/images/selfrepair-260x260.png" alt="A Mossy Cobblestone." title="">
             </div>
 
             <div class="media-content">
@@ -728,7 +728,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 60%;">
-                <img src="assets/images/sharpness-239x137.jpg" alt="Modifiers" title="">
+                <img src="assets/images/sharpness-239x137.jpg" alt="9 Blocks of Quartz." title="Can be crafted through a crafting table.">
             </div>
 
             <div class="media-content">
@@ -754,7 +754,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 60%;">
-                <img src="assets/images/shulking-240x135.jpg" alt="Modifiers" title="">
+                <img src="assets/images/shulking-240x135.jpg" alt="A Chorus Flower on the middle and 2 Shulker Shells on middle top and middle bottom slots." title="Can be crafted through a crafting table.">
             </div>
 
             <div class="media-content">
@@ -780,7 +780,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 20%;">
-                <img src="assets/images/silktouch-256x256.png" alt="Modifiers" title="">
+                <img src="assets/images/silktouch-256x256.png" alt="A Cobweb." title="">
             </div>
 
             <div class="media-content">
@@ -806,7 +806,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 60%;">
-                <img src="assets/images/soulbound-250x141.png" alt="Modifiers" title="">
+                <img src="assets/images/soulbound-250x141.png" alt="4 Blaze Rods on corner, a Nether Star on the middle and 4 Lava Buckets on the 4 empty slots." title="Can be crafted through a crafting table.">
             </div>
 
             <div class="media-content">
@@ -832,7 +832,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 20%;">
-                <img src="assets/images/sweeping-150x150.png" alt="Modifiers" title="">
+                <img src="assets/images/sweeping-150x150.png" alt="An Iron Ingot." title="">
             </div>
 
             <div class="media-content">
@@ -858,7 +858,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 60%;">
-                <img src="assets/images/timber-255x142.jpg" alt="Modifiers" title="">
+                <img src="assets/images/timber-255x142.jpg" alt="An Emerald surrounded by 8 Oak Wood Barks." title="Can be crafted through a crafting table.">
             </div>
 
             <div class="media-content">
@@ -884,7 +884,7 @@
     <div class="container">
         <div class="media-container-row">
             <div class="mbr-figure" style="width: 60%;">
-                <img src="assets/images/webbed-249x145.png" alt="Modifiers" title="">
+                <img src="assets/images/webbed-249x145.png" alt="9 Cobwebs." title="Can be crafted through a crafting table.">
             </div>
 
             <div class="media-content">


### PR DESCRIPTION
Some modifiers' recipe items couldn't be understood by looking (for example: sharpness either uses Block Of Quartz or Smooth Quartz)

In the case of having a slow internet, the user still should be able to get the recipe too.