### PR TITLE
Bug fixes and feature additions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ hs_err_pid*
 .idea/modules.xml
 .idea/*.iml
 .idea/modules
+.idea/misc.xml
 
 # Maven generated files
 /target/

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,8 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>craftbukkit</artifactId>
-            <version>1.14-R0.1-SNAPSHOT</version>
+            <version>1.14.1-R0.1-SNAPSHOT</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>

--- a/src/main/java/de/flo56958/MineTinker/Commands/Commands.java
+++ b/src/main/java/de/flo56958/MineTinker/Commands/Commands.java
@@ -17,6 +17,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -302,14 +303,13 @@ public class Commands implements TabExecutor {
         ChatWriter.sendMessage(sender, ChatColor.WHITE, "Done reloading!");
 
         if (config.getBoolean("CheckForUpdates")) {
-            Bukkit.getScheduler().scheduleAsyncDelayedTask(Main.getPlugin(), () -> {
-                Main.getUpdater().checkForUpdate();
-            }, 20);
+            Bukkit.getScheduler().scheduleAsyncDelayedTask(Main.getPlugin(),
+                    () -> Main.getUpdater().checkForUpdate(), 20);
         }
     }
 
     @Override
-    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+    public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
         ArrayList<String> result = new ArrayList<>();
         ArrayList<String> numbers = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
@@ -372,14 +372,14 @@ public class Commands implements TabExecutor {
                 switch (args[0]) {
                     case "givemodifieritem":
                     case "gm":
-                        for(Player p : Bukkit.getOnlinePlayers()) {
+                        for (Player p : Bukkit.getOnlinePlayers()) {
                             result.add(p.getName());
                         }
                         break;
                 }
         }
 
-        result.removeIf(s -> !s.toLowerCase().startsWith(args[args.length - 1].toLowerCase()));
+        result.removeIf (s -> !s.toLowerCase().startsWith(args[args.length - 1].toLowerCase()));
         // filter out any command that is not the beginning of the typed command
 
         return result;

--- a/src/main/java/de/flo56958/MineTinker/Commands/Commands.java
+++ b/src/main/java/de/flo56958/MineTinker/Commands/Commands.java
@@ -16,7 +16,6 @@ import org.bukkit.command.TabExecutor;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Recipe;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -274,15 +273,19 @@ public class Commands implements TabExecutor {
         ChatWriter.sendMessage(sender, ChatColor.RED, "NOTE: Elevator and Builderswands need a complete restart to function correctly on the new configurations!");
 
         ChatWriter.sendMessage(sender, ChatColor.WHITE, "Clearing recipes!");
+
         Iterator<Recipe> it = Main.getPlugin().getServer().recipeIterator(); //TODO: Better algorithm for removing recipes from modifiers
+
         while (it.hasNext()) {
             Recipe rec = it.next();
+
             for (Modifier mod : modManager.getAllowedMods()) {
                 if (mod.getModItem().equals(rec.getResult())) {
                     it.remove();
                     break;
                 }
             }
+
             if (BuildersWandListener.getWands().contains(rec.getResult())) {
                 it.remove();
             }
@@ -312,6 +315,7 @@ public class Commands implements TabExecutor {
     public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
         ArrayList<String> result = new ArrayList<>();
         ArrayList<String> numbers = new ArrayList<>();
+
         for (int i = 0; i < 10; i++) {
             numbers.add(Integer.toString(i));
         }

--- a/src/main/java/de/flo56958/MineTinker/Commands/Commands.java
+++ b/src/main/java/de/flo56958/MineTinker/Commands/Commands.java
@@ -302,12 +302,9 @@ public class Commands implements TabExecutor {
         ChatWriter.sendMessage(sender, ChatColor.WHITE, "Done reloading!");
 
         if (config.getBoolean("CheckForUpdates")) {
-            new BukkitRunnable() {
-                @Override
-                public void run() {
-                    Main.getUpdater().checkForUpdate(sender);
-                }
-            }.runTaskLater(Main.getPlugin(), 20);
+            Bukkit.getScheduler().scheduleAsyncDelayedTask(Main.getPlugin(), () -> {
+                Main.getUpdater().checkForUpdate();
+            }, 20);
         }
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Commands/Functions.java
+++ b/src/main/java/de/flo56958/MineTinker/Commands/Functions.java
@@ -177,12 +177,14 @@ class Functions {
             return;
         }
 
-        ItemStack tool = new ItemStack(material, 1);
-        modManager.convertItemStack(tool);
+        if (material != null) {
+            ItemStack tool = new ItemStack(material, 1);
+            modManager.convertItemStack(tool);
 
-        if (player.getInventory().addItem(tool).size() != 0) { //adds items to (full) inventory
-            player.getWorld().dropItem(player.getLocation(), tool);
-        } // no else as it gets added in if
+            if (player.getInventory().addItem(tool).size() != 0) { //adds items to (full) inventory
+                player.getWorld().dropItem(player.getLocation(), tool);
+            } // no else as it gets added in if
+        }
     }
 
     /**

--- a/src/main/java/de/flo56958/MineTinker/Commands/Functions.java
+++ b/src/main/java/de/flo56958/MineTinker/Commands/Functions.java
@@ -221,6 +221,8 @@ class Functions {
      * @param args command input of the player - parsed down from onCommand()
      */
     public static void giveModifierItem(Player player, String[] args) {
+        boolean allOnline = false;
+
         if (args.length >= 2) {
             for (Modifier mod : modManager.getAllowedMods()) {
                 if (mod.getName().equalsIgnoreCase(args[1])) {
@@ -236,20 +238,36 @@ class Functions {
                     }
 
                     if (args.length >= 4) {
-                        Player temp = Bukkit.getServer().getPlayer(args[3]);
+                        if (args[3].equalsIgnoreCase("*")) {
+                            allOnline = true;
+                        } else {
+                            Player temp = Bukkit.getServer().getPlayer(args[3]);
 
-                        if (temp == null) {
-                            ChatWriter.sendMessage(player, ChatColor.RED, "Player " + args[3] + " not found or not online!");
-                            return;
+                            if (temp == null) {
+                                ChatWriter.sendMessage(player, ChatColor.RED, "Player " + args[3] + " not found or not online!");
+                                return;
+                            }
+                            player = temp;
                         }
-                        player = temp;
+
                     }
 
-                    for (int i = 0; i < amount; i++) {
-                        if (player.getInventory().addItem(mod.getModItem()).size() != 0) { //adds items to (full) inventory
-                            player.getWorld().dropItem(player.getLocation(), mod.getModItem());
-                        } // no else as it gets added in if
+                    if (allOnline) {
+                        for (Player onlinePlayer : Bukkit.getServer().getOnlinePlayers()) {
+                            for (int i = 0; i < amount; i++) {
+                                if (onlinePlayer.getInventory().addItem(mod.getModItem()).size() != 0) { //adds items to (full) inventory
+                                    onlinePlayer.getWorld().dropItem(onlinePlayer.getLocation(), mod.getModItem());
+                                } // no else as it gets added in if
+                            }
+                        }
+                    } else {
+                        for (int i = 0; i < amount; i++) {
+                            if (player.getInventory().addItem(mod.getModItem()).size() != 0) { //adds items to (full) inventory
+                                player.getWorld().dropItem(player.getLocation(), mod.getModItem());
+                            } // no else as it gets added in if
+                        }
                     }
+
                     break;
                 }
             }

--- a/src/main/java/de/flo56958/MineTinker/Commands/Functions.java
+++ b/src/main/java/de/flo56958/MineTinker/Commands/Functions.java
@@ -25,7 +25,9 @@ class Functions {
      */
     static void modList(CommandSender sender) {
         ChatWriter.sendMessage(sender, ChatColor.GOLD, "Possible Modifiers:");
+
         int index = 1;
+
         for (Modifier m : modManager.getAllowedMods()) {
             ChatWriter.sendMessage(sender, ChatColor.WHITE, index + ". " + m.getColor() + m.getName() + ChatColor.WHITE + ": " + m.getDescription());
             index++;
@@ -40,6 +42,7 @@ class Functions {
     static void addExp(Player player, String[] args) {
         if (args.length == 2) {
             ItemStack tool = player.getInventory().getItemInMainHand();
+
             if (modManager.isToolViable(tool) || modManager.isArmorViable(tool)) {
                 try {
                     int amount = Integer.parseInt(args[1]);
@@ -63,15 +66,22 @@ class Functions {
     static void name(Player player, String[] args) {
         if (args.length >= 2) {
             ItemStack tool = player.getInventory().getItemInMainHand();
+
             if (modManager.isToolViable(tool) || modManager.isArmorViable(tool)) {
                 StringBuilder name = new StringBuilder();
+
                 for (int i = 1; i < args.length; i++) {
                     name.append(" ").append(args[i].replace('^', '§'));
                 }
+
                 name = new StringBuilder(name.substring(1));
-                ItemMeta meta = tool.getItemMeta().clone();
-                meta.setDisplayName(name.toString());
-                tool.setItemMeta(meta);
+
+                ItemMeta meta = tool.getItemMeta();
+
+                if (meta != null) {
+                    meta.setDisplayName(name.toString());
+                    tool.setItemMeta(meta);
+                }
             } else {
                 Commands.invalidTool(player);
             }
@@ -88,7 +98,9 @@ class Functions {
     static void removeMod(Player player, String[] args) {
         if (args.length >= 2) {
             ItemStack tool = player.getInventory().getItemInMainHand();
+
             if (!modManager.isToolViable(tool) && !modManager.isArmorViable(tool)) { Commands.invalidArgs(player); return; }
+
             for (Modifier m : modManager.getAllMods()) {
                 if (args[1].equals(m.getName())) {
                     modManager.removeMod(player.getInventory().getItemInMainHand(), m);
@@ -111,8 +123,10 @@ class Functions {
             for (Modifier m : modManager.getAllowedMods()) {
                 if (m.getName().equalsIgnoreCase(args[1])) {
                     ItemStack tool = player.getInventory().getItemInMainHand().clone();
+
                     if (modManager.isToolViable(tool) || modManager.isArmorViable(tool)) {
                         tool = m.applyMod(player, tool, true);
+
                         if (tool != null) {
                             player.getInventory().setItemInMainHand(tool);
                         }
@@ -134,21 +148,23 @@ class Functions {
 	static void setDurability(Player player, String[] args) {
         if (args.length == 2) {
             ItemStack tool = player.getInventory().getItemInMainHand();
+
             if (modManager.isToolViable(tool) || modManager.isArmorViable(tool)) {
-                        try {
-                            int dura = Integer.parseInt(args[1]);
-                            if (dura <= tool.getType().getMaxDurability()) {
-                                tool.setDurability((short) (tool.getType().getMaxDurability() - dura));
-                            } else {
-                                ChatWriter.sendMessage(player, ChatColor.RED, "Please enter a valid number or 'full'!");
-                            }
-                        } catch (Exception e) {
-                            if (args[1].toLowerCase().equals("full") || args[1].toLowerCase().equals("f")) {
-                                tool.setDurability((short) 0);
-                            } else {
-                                ChatWriter.sendMessage(player, ChatColor.RED, "Please enter a valid number or 'full'!");
-                            }
-                        }
+                try {
+                    int dura = Integer.parseInt(args[1]);
+
+                    if (dura <= tool.getType().getMaxDurability()) {
+                        tool.setDurability((short) (tool.getType().getMaxDurability() - dura));
+                    } else {
+                        ChatWriter.sendMessage(player, ChatColor.RED, "Please enter a valid number or 'full'!");
+                    }
+                } catch (Exception e) {
+                    if (args[1].toLowerCase().equals("full") || args[1].toLowerCase().equals("f")) {
+                        tool.setDurability((short) 0);
+                    } else {
+                        ChatWriter.sendMessage(player, ChatColor.RED, "Please enter a valid number or 'full'!");
+                    }
+                }
             } else {
                 Commands.invalidTool(player);
             }
@@ -181,14 +197,12 @@ class Functions {
             return;
         }
 
-        if (material != null) {
-            ItemStack tool = new ItemStack(material, 1);
-            modManager.convertItemStack(tool);
+        ItemStack tool = new ItemStack(material, 1);
+        modManager.convertItemStack(tool);
 
-            if (player.getInventory().addItem(tool).size() != 0) { //adds items to (full) inventory
-                player.getWorld().dropItem(player.getLocation(), tool);
-            } // no else as it gets added in if
-        }
+        if (player.getInventory().addItem(tool).size() != 0) { //adds items to (full) inventory
+            player.getWorld().dropItem(player.getLocation(), tool);
+        } // no else as it gets added in if
     }
 
     /**
@@ -211,6 +225,7 @@ class Functions {
             for (Modifier mod : modManager.getAllowedMods()) {
                 if (mod.getName().equalsIgnoreCase(args[1])) {
                     int amount = 1;
+
                     if (args.length >= 3) {
                         try {
                             amount = Integer.parseInt(args[2]);
@@ -219,14 +234,17 @@ class Functions {
                             return;
                         }
                     }
+
                     if (args.length >= 4) {
                         Player temp = Bukkit.getServer().getPlayer(args[3]);
+
                         if (temp == null) {
                             ChatWriter.sendMessage(player, ChatColor.RED, "Player " + args[3] + " not found or not online!");
                             return;
                         }
                         player = temp;
                     }
+
                     for (int i = 0; i < amount; i++) {
                         if (player.getInventory().addItem(mod.getModItem()).size() != 0) { //adds items to (full) inventory
                             player.getWorld().dropItem(player.getLocation(), mod.getModItem());
@@ -241,12 +259,15 @@ class Functions {
     public static void checkUpdate(CommandSender sender) {
         if (config.getBoolean("CheckForUpdates")) {
             ChatWriter.sendMessage(sender, ChatColor.WHITE, "Checking for Updates...");
+
             new BukkitRunnable() {
                 @Override
                 public void run() {
                     Main.getUpdater().checkForUpdate(sender);
                 }
             }.runTaskLater(Main.getPlugin(), 20);
-        } else ChatWriter.sendMessage(sender, ChatColor.RED, "Checking for updates is disabled by the server admin!");
+        } else {
+            ChatWriter.sendMessage(sender, ChatColor.RED, "Checking for updates is disabled by the server admin!");
+        }
     }
 }

--- a/src/main/java/de/flo56958/MineTinker/Data/CraftingRecipes.java
+++ b/src/main/java/de/flo56958/MineTinker/Data/CraftingRecipes.java
@@ -65,6 +65,7 @@ public class CraftingRecipes {
 
             // TODO: Make safe
             newRecipe.shape(top, middle, bottom); //makes recipe
+
             for (String key : materials.getKeys(false)) {
                 newRecipe.setIngredient(key.charAt(0), Material.getMaterial(materials.getString(key)));
             }
@@ -83,7 +84,9 @@ public class CraftingRecipes {
     public static void registerMTElytra() {
         FileConfiguration config = ConfigurationManager.getConfig("Elytra.yml");
         String ckey = "Elytra";
+
         if (!config.getBoolean(ckey + ".craftable")) return;
+
         try {
             NamespacedKey nkey = new NamespacedKey(Main.getPlugin(), "MineTinker_Elytra");
             ItemStack elytra = new ItemStack(Material.ELYTRA, 1);
@@ -93,10 +96,14 @@ public class CraftingRecipes {
             String middle = config.getString(ckey + ".Recipe.Middle");
             String bottom = config.getString(ckey + ".Recipe.Bottom");
             ConfigurationSection materials = config.getConfigurationSection(ckey + ".Recipe.Materials");
+
+            // TODO: Make safe
             newRecipe.shape(top, middle, bottom); //makes recipe
+
             for (String key : materials.getKeys(false)) {
                 newRecipe.setIngredient(key.charAt(0), Material.getMaterial(materials.getString(key)));
             }
+
             Main.getPlugin().getServer().addRecipe(newRecipe); //adds recipe
             ModManager.instance().recipe_Namespaces.add(nkey);
         } catch (Exception e) {
@@ -124,10 +131,14 @@ public class CraftingRecipes {
             String middle = config.getString(ckey + ".Recipe.Middle");
             String bottom = config.getString(ckey + ".Recipe.Bottom");
             ConfigurationSection materials = config.getConfigurationSection(ckey + ".Recipe.Materials");
+
+            // TODO: Make safe
             newRecipe.shape(top, middle, bottom); //makes recipe
+
             for (String key : materials.getKeys(false)) {
                 newRecipe.setIngredient(key.charAt(0), Material.getMaterial(materials.getString(key)));
             }
+
             Main.getPlugin().getServer().addRecipe(newRecipe); //adds recipe
             ModManager.instance().recipe_Namespaces.add(nkey);
         } catch (Exception e) {

--- a/src/main/java/de/flo56958/MineTinker/Data/CraftingRecipes.java
+++ b/src/main/java/de/flo56958/MineTinker/Data/CraftingRecipes.java
@@ -62,10 +62,13 @@ public class CraftingRecipes {
             String middle = config.getString("Elevator.Recipe.Middle");
             String bottom = config.getString("Elevator.Recipe.Bottom");
             ConfigurationSection materials = config.getConfigurationSection("Elevator.Recipe.Materials");
+
+            // TODO: Make safe
             newRecipe.shape(top, middle, bottom); //makes recipe
             for (String key : materials.getKeys(false)) {
                 newRecipe.setIngredient(key.charAt(0), Material.getMaterial(materials.getString(key)));
             }
+
             Main.getPlugin().getServer().addRecipe(newRecipe); //adds recipe
             ModManager.instance().recipe_Namespaces.add(nkey);
         } catch (Exception e) {
@@ -80,7 +83,7 @@ public class CraftingRecipes {
     public static void registerMTElytra() {
         FileConfiguration config = ConfigurationManager.getConfig("Elytra.yml");
         String ckey = "Elytra";
-        if (!config.getBoolean(ckey + ".craftable")) { return; }
+        if (!config.getBoolean(ckey + ".craftable")) return;
         try {
             NamespacedKey nkey = new NamespacedKey(Main.getPlugin(), "MineTinker_Elytra");
             ItemStack elytra = new ItemStack(Material.ELYTRA, 1);
@@ -111,7 +114,7 @@ public class CraftingRecipes {
     public static void registerMTTrident() {
         FileConfiguration config = ConfigurationManager.getConfig("Trident.yml");
         String ckey = "Trident";
-        if (!config.getBoolean(ckey + ".craftable")) { return; }
+        if (!config.getBoolean(ckey + ".craftable")) return;
         try {
             NamespacedKey nkey = new NamespacedKey(Main.getPlugin(), "MineTinker_Trident");
             ItemStack trident = new ItemStack(Material.TRIDENT, 1);

--- a/src/main/java/de/flo56958/MineTinker/Data/ToolType.java
+++ b/src/main/java/de/flo56958/MineTinker/Data/ToolType.java
@@ -24,7 +24,6 @@ public enum ToolType {
 	SHIELD,
 	SHOVEL,
 	SWORD,
-
 	TRIDENT;
 
 	/**

--- a/src/main/java/de/flo56958/MineTinker/Events/MTBlockBreakEvent.java
+++ b/src/main/java/de/flo56958/MineTinker/Events/MTBlockBreakEvent.java
@@ -46,6 +46,7 @@ public class MTBlockBreakEvent extends Event implements Cancellable {
      */
     public BlockBreakEvent getEvent() { return event; }
 
+    @NotNull
     @Override
     public HandlerList getHandlers() {
         return handlers;

--- a/src/main/java/de/flo56958/MineTinker/Events/MTEntityDamageByEntityEvent.java
+++ b/src/main/java/de/flo56958/MineTinker/Events/MTEntityDamageByEntityEvent.java
@@ -70,6 +70,7 @@ public class MTEntityDamageByEntityEvent extends Event implements Cancellable {
         return event;
     }
 
+    @NotNull
     @Override
     public HandlerList getHandlers() {
         return handlers;

--- a/src/main/java/de/flo56958/MineTinker/Events/MTEntityDamageEvent.java
+++ b/src/main/java/de/flo56958/MineTinker/Events/MTEntityDamageEvent.java
@@ -63,6 +63,7 @@ public class MTEntityDamageEvent extends Event implements Cancellable {
         return event;
     }
 
+    @NotNull
     @Override
     public HandlerList getHandlers() {
         return handlers;

--- a/src/main/java/de/flo56958/MineTinker/Events/MTEntityDeathEvent.java
+++ b/src/main/java/de/flo56958/MineTinker/Events/MTEntityDeathEvent.java
@@ -44,6 +44,7 @@ public class MTEntityDeathEvent extends Event {
      */
     public EntityDeathEvent getEvent() { return event; }
 
+    @NotNull
     @Override
     public HandlerList getHandlers() {
         return handlers;

--- a/src/main/java/de/flo56958/MineTinker/Events/MTPlayerInteractEvent.java
+++ b/src/main/java/de/flo56958/MineTinker/Events/MTPlayerInteractEvent.java
@@ -45,6 +45,7 @@ public class MTPlayerInteractEvent extends Event implements Cancellable {
      */
     public PlayerInteractEvent getEvent() { return event; }
 
+    @NotNull
     @Override
     public HandlerList getHandlers() {
         return handlers;

--- a/src/main/java/de/flo56958/MineTinker/Events/MTProjectileHitEvent.java
+++ b/src/main/java/de/flo56958/MineTinker/Events/MTProjectileHitEvent.java
@@ -46,6 +46,7 @@ public class MTProjectileHitEvent extends Event {
         return event;
     }
 
+    @NotNull
     @Override
     public HandlerList getHandlers() {
         return handlers;

--- a/src/main/java/de/flo56958/MineTinker/Events/ModifierApplyEvent.java
+++ b/src/main/java/de/flo56958/MineTinker/Events/ModifierApplyEvent.java
@@ -54,6 +54,7 @@ public class ModifierApplyEvent extends Event {
         return isCommand;
     }
 
+    @NotNull
     @Override
     public HandlerList getHandlers() {
         return handlers;

--- a/src/main/java/de/flo56958/MineTinker/Events/ModifierFailEvent.java
+++ b/src/main/java/de/flo56958/MineTinker/Events/ModifierFailEvent.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
 public class ModifierFailEvent extends Event {
 
@@ -67,6 +68,7 @@ public class ModifierFailEvent extends Event {
 
     public boolean isCommand() { return isCommand; }
 
+    @NotNull
     @Override
     public HandlerList getHandlers() {
         return handlers;

--- a/src/main/java/de/flo56958/MineTinker/Events/ToolLevelUpEvent.java
+++ b/src/main/java/de/flo56958/MineTinker/Events/ToolLevelUpEvent.java
@@ -30,6 +30,7 @@ public class ToolLevelUpEvent extends Event {
         return tool;
     }
 
+    @NotNull
     @Override
     public HandlerList getHandlers() {
         return handlers;

--- a/src/main/java/de/flo56958/MineTinker/Events/ToolUpgradeEvent.java
+++ b/src/main/java/de/flo56958/MineTinker/Events/ToolUpgradeEvent.java
@@ -4,6 +4,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
 public class ToolUpgradeEvent extends Event {
 
@@ -25,6 +26,7 @@ public class ToolUpgradeEvent extends Event {
         this.wasSuccessful = wasSuccessful;
     }
 
+    @NotNull
     @Override
     public HandlerList getHandlers() { return handlers; }
 

--- a/src/main/java/de/flo56958/MineTinker/Listeners/AnvilListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/AnvilListener.java
@@ -52,16 +52,20 @@ public class AnvilListener implements Listener {
 
         if (!modManager.isModifierItem(modifier)) { //upgrade
             if (tool.getType().equals(newTool.getType())) return; //Not an upgrade
+
             // ------ upgrade
             if (e.isShiftClick()) {
                 if (player.getInventory().addItem(newTool).size() != 0) { //adds items to (full) inventory and then case if inventory is full
                     e.setCancelled(true); //cancels the event if the player has a full inventory
                     return;
                 } // no else as it gets added in if-clause
+
                 inv.clear();
                 return;
             }
+
             Bukkit.getPluginManager().callEvent(new ToolUpgradeEvent(player, newTool, true));
+
             player.setItemOnCursor(newTool);
             inv.clear();
         } else { //is modifier
@@ -76,11 +80,14 @@ public class AnvilListener implements Listener {
                     e.setCancelled(true); //cancels the event if the player has a full inventory
                     return;
                 } // no else as it gets added in if-clause
+
                 inv.clear();
                 inv.setItem(1, modifier);
                 return;
             }
+
             player.setItemOnCursor(newTool);
+
             inv.clear();
             inv.setItem(1, modifier);
         }
@@ -180,7 +187,9 @@ public class AnvilListener implements Listener {
     public void onGrind(InventoryClickEvent e) {
 	    if (!(e.getInventory() instanceof GrindstoneInventory)) return;
 	    if (e.getSlot() != 9) return;
+
 	    ItemStack results = e.getCurrentItem();
+
 	    if (modManager.isToolViable(results) || modManager.isArmorViable(results)) {
 	        e.setCancelled(true);
 	    }

--- a/src/main/java/de/flo56958/MineTinker/Listeners/AnvilListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/AnvilListener.java
@@ -33,7 +33,7 @@ public class AnvilListener implements Listener {
 	public void onInventoryClick(InventoryClickEvent e) {
 		HumanEntity he = e.getWhoClicked();
 		
-		if(!(he instanceof Player && e.getClickedInventory() instanceof AnvilInventory)) { return; }
+		if (!(he instanceof Player && e.getClickedInventory() instanceof AnvilInventory)) return;
         AnvilInventory inv = (AnvilInventory) e.getClickedInventory();
         Player player = (Player) he;
 
@@ -41,17 +41,17 @@ public class AnvilListener implements Listener {
         ItemStack modifier = inv.getItem(1);
         ItemStack newTool = inv.getItem(2);
 
-        if (tool == null || modifier == null || newTool == null) { return; }
+        if (tool == null || modifier == null || newTool == null) return;
 
-        if (e.getSlot() != 2) { return; }
-        if (Lists.WORLDS.contains(player.getWorld().getName())) { return; }
-        if (!(modManager.isToolViable(tool) || modManager.isArmorViable(tool))) { return; }
+        if (e.getSlot() != 2) return;
+        if (Lists.WORLDS.contains(player.getWorld().getName())) return;
+        if (!(modManager.isToolViable(tool) || modManager.isArmorViable(tool))) return;
 
-        boolean deleteAllItems = false;
-        if (e.getCursor() != null && !e.getCursor().getType().equals(Material.AIR)) { return; }
+        //boolean deleteAllItems = false;
+        if (e.getCursor() != null && !e.getCursor().getType().equals(Material.AIR)) return;
 
         if (!modManager.isModifierItem(modifier)) { //upgrade
-            if (tool.getType().equals(newTool.getType())) { return; } //Not an upgrade
+            if (tool.getType().equals(newTool.getType())) return; //Not an upgrade
             // ------ upgrade
             if (e.isShiftClick()) {
                 if (player.getInventory().addItem(newTool).size() != 0) { //adds items to (full) inventory and then case if inventory is full
@@ -126,47 +126,51 @@ public class AnvilListener implements Listener {
             newTool = mod.applyMod(player, tool.clone(), false);
         } else {
             if (config.getBoolean("Upgradeable") && player.hasPermission("minetinker.tool.upgrade")) {
-                switch (i.getItem(1).getAmount()) {
-                    case 1:
-                        if (ToolType.SHOVEL.getMaterials().contains(tool.getType())) {
-                            newTool = ItemGenerator.itemUpgrader(tool.clone(), i.getItem(1), player);
-                        }
-                        break;
-                    case 2:
-                        if (ToolType.SWORD.getMaterials().contains(tool.getType()) || ToolType.HOE.getMaterials().contains(tool.getType())) {
-                            newTool = ItemGenerator.itemUpgrader(tool.clone(), i.getItem(1), player);
-                        }
-                        break;
-                    case 3:
-                        if (ToolType.AXE.getMaterials().contains(tool.getType()) || ToolType.PICKAXE.getMaterials().contains(tool.getType())) {
-                            newTool = ItemGenerator.itemUpgrader(tool.clone(), i.getItem(1), player);
-                        }
-                        break;
-                    case 4:
-                        if (ToolType.BOOTS.getMaterials().contains(tool.getType())) {
-                            newTool = ItemGenerator.itemUpgrader(tool.clone(), i.getItem(1), player);
-                        }
-                        break;
-                    case 5:
-                        if (ToolType.HELMET.getMaterials().contains(tool.getType())) {
-                            newTool = ItemGenerator.itemUpgrader(tool.clone(), i.getItem(1), player);
-                        }
-                        break;
-                    case 7:
-                        if (ToolType.LEGGINGS.getMaterials().contains(tool.getType())) {
-                            newTool = ItemGenerator.itemUpgrader(tool.clone(), i.getItem(1), player);
-                        }
-                        break;
-                    case 8:
-                        if (ToolType.CHESTPLATE.getMaterials().contains(tool.getType())) {
-                            newTool = ItemGenerator.itemUpgrader(tool.clone(), i.getItem(1), player);
-                        }
-                        break;
+                ItemStack item = i.getItem(1);
+
+                if (item != null) {
+                    switch (item.getAmount()) {
+                        case 1:
+                            if (ToolType.SHOVEL.getMaterials().contains(tool.getType())) {
+                                newTool = ItemGenerator.itemUpgrader(tool.clone(), i.getItem(1), player);
+                            }
+                            break;
+                        case 2:
+                            if (ToolType.SWORD.getMaterials().contains(tool.getType()) || ToolType.HOE.getMaterials().contains(tool.getType())) {
+                                newTool = ItemGenerator.itemUpgrader(tool.clone(), i.getItem(1), player);
+                            }
+                            break;
+                        case 3:
+                            if (ToolType.AXE.getMaterials().contains(tool.getType()) || ToolType.PICKAXE.getMaterials().contains(tool.getType())) {
+                                newTool = ItemGenerator.itemUpgrader(tool.clone(), i.getItem(1), player);
+                            }
+                            break;
+                        case 4:
+                            if (ToolType.BOOTS.getMaterials().contains(tool.getType())) {
+                                newTool = ItemGenerator.itemUpgrader(tool.clone(), i.getItem(1), player);
+                            }
+                            break;
+                        case 5:
+                            if (ToolType.HELMET.getMaterials().contains(tool.getType())) {
+                                newTool = ItemGenerator.itemUpgrader(tool.clone(), i.getItem(1), player);
+                            }
+                            break;
+                        case 7:
+                            if (ToolType.LEGGINGS.getMaterials().contains(tool.getType())) {
+                                newTool = ItemGenerator.itemUpgrader(tool.clone(), i.getItem(1), player);
+                            }
+                            break;
+                        case 8:
+                            if (ToolType.CHESTPLATE.getMaterials().contains(tool.getType())) {
+                                newTool = ItemGenerator.itemUpgrader(tool.clone(), i.getItem(1), player);
+                            }
+                            break;
+                    }
                 }
             }
         }
         
-        if(newTool != null) {
+        if (newTool != null) {
         	e.setResult(newTool);
         	i.setRepairCost(0);
         }

--- a/src/main/java/de/flo56958/MineTinker/Listeners/ArmorListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/ArmorListener.java
@@ -30,11 +30,9 @@ public class ArmorListener implements Listener {
     private static final ModManager modManager = ModManager.instance();
     private static final FileConfiguration config = Main.getPlugin().getConfig();
 
-    @EventHandler(priority = EventPriority.NORMAL)
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onEntityDamage(EntityDamageByEntityEvent e) {
-        if (e.isCancelled()) return;
         if (Lists.WORLDS.contains(e.getEntity().getWorld().getName())) return;
-
         if (!(e.getEntity() instanceof Player)) return;
 
         Player p = (Player) e.getEntity();
@@ -46,6 +44,7 @@ public class ArmorListener implements Listener {
         if (ent instanceof Arrow) {
             Arrow arrow = (Arrow) ent;
             ProjectileSource source = arrow.getShooter();
+
             if (source instanceof Entity) {
                 ent = (Entity) source;
             } else {
@@ -61,18 +60,18 @@ public class ArmorListener implements Listener {
             Bukkit.getPluginManager().callEvent(new MTEntityDamageByEntityEvent(p, piece, ent, e));
 
             int amount = config.getInt("ExpPerEntityHit");
+
             if (config.getBoolean("EnableDamageExp")) {
                 amount = (int) e.getDamage();
             }
+
             modManager.addExp(p, piece, amount);
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onPlayerDamage(EntityDamageEvent e) {
-        if (e.isCancelled()) return;
         if (Lists.WORLDS.contains(e.getEntity().getWorld().getName())) return;
-
         if (!(e.getEntity() instanceof Player)) return;
 
         Player p = (Player) e.getEntity();
@@ -85,27 +84,28 @@ public class ArmorListener implements Listener {
             Bukkit.getPluginManager().callEvent(new MTEntityDamageEvent(p, piece, e));
 
             int amount = config.getInt("ExpPerEntityHit") / 2;
+
             if (config.getBoolean("EnableDamageExp")) {
                 amount = (int) e.getDamage() / 2;
             }
+
             modManager.addExp(p, piece, amount);
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onElytraDamage(PlayerItemDamageEvent e) {
-        if (e.isCancelled()) return;
-
         if (!e.getPlayer().isGliding()) return;
-
         if (!e.getItem().getType().equals(Material.ELYTRA)) return;
         if (!modManager.isArmorViable(e.getItem())) return;
 
         Random rand = new Random();
         int chance = rand.nextInt(100);
+
         if (chance < ConfigurationManager.getConfig("Elytra.yml").getInt("Elytra.ExpChanceWhileFlying")) {
             modManager.addExp(e.getPlayer(), e.getItem(), config.getInt("ExpPerEntityHit"));
         }
+
         ((SelfRepair) modManager.getAdmin(ModifierType.SELF_REPAIR)).effectElytra(e.getPlayer(), e.getItem());
     }
 }

--- a/src/main/java/de/flo56958/MineTinker/Listeners/ArmorListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/ArmorListener.java
@@ -32,14 +32,14 @@ public class ArmorListener implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL)
     public void onEntityDamage(EntityDamageByEntityEvent e) {
-        if (e.isCancelled()) { return; }
-        if (Lists.WORLDS.contains(e.getEntity().getWorld().getName())) { return; }
+        if (e.isCancelled()) return;
+        if (Lists.WORLDS.contains(e.getEntity().getWorld().getName())) return;
 
-        if (!(e.getEntity() instanceof Player)) { return; }
+        if (!(e.getEntity() instanceof Player)) return;
 
         Player p = (Player) e.getEntity();
 
-        //if (p.isBlocking()) { return; } //does not really work
+        //if (p.isBlocking()) return; //does not really work
 
         Entity ent = e.getDamager();
 
@@ -70,10 +70,10 @@ public class ArmorListener implements Listener {
 
     @EventHandler
     public void onPlayerDamage(EntityDamageEvent e) {
-        if (e.isCancelled()) { return; }
-        if (Lists.WORLDS.contains(e.getEntity().getWorld().getName())) { return; }
+        if (e.isCancelled()) return;
+        if (Lists.WORLDS.contains(e.getEntity().getWorld().getName())) return;
 
-        if (!(e.getEntity() instanceof Player)) { return; }
+        if (!(e.getEntity() instanceof Player)) return;
 
         Player p = (Player) e.getEntity();
 
@@ -94,12 +94,12 @@ public class ArmorListener implements Listener {
 
     @EventHandler
     public void onElytraDamage(PlayerItemDamageEvent e) {
-        if (e.isCancelled()) { return; }
+        if (e.isCancelled()) return;
 
-        if (!e.getPlayer().isGliding()) { return; }
+        if (!e.getPlayer().isGliding()) return;
 
-        if (!e.getItem().getType().equals(Material.ELYTRA)) { return; }
-        if (!modManager.isArmorViable(e.getItem())) { return; }
+        if (!e.getItem().getType().equals(Material.ELYTRA)) return;
+        if (!modManager.isArmorViable(e.getItem())) return;
 
         Random rand = new Random();
         int chance = rand.nextInt(100);

--- a/src/main/java/de/flo56958/MineTinker/Listeners/BuildersWandListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/BuildersWandListener.java
@@ -102,12 +102,14 @@ public class BuildersWandListener implements Listener {
 
     public static void reload() {
         config = ConfigurationManager.getConfig("BuildersWand.yml");
+
         wands.clear();
         wands.add(buildersWandCreator(Material.WOODEN_SHOVEL, config.getString("BuildersWand.name_wood")));
         wands.add(buildersWandCreator(Material.STONE_SHOVEL, config.getString("BuildersWand.name_stone")));
         wands.add(buildersWandCreator(Material.IRON_SHOVEL, config.getString("BuildersWand.name_iron")));
         wands.add(buildersWandCreator(Material.GOLDEN_SHOVEL, config.getString("BuildersWand.name_gold")));
         wands.add(buildersWandCreator(Material.DIAMOND_SHOVEL, config.getString("BuildersWand.name_diamond")));
+
         registerBuildersWands();
     }
 
@@ -117,17 +119,21 @@ public class BuildersWandListener implements Listener {
 
         if (meta != null) {
             ArrayList<String> lore = new ArrayList<>();
-            meta.setDisplayName(ChatWriter.addColors(name));
+
             lore.add(ChatWriter.addColors(config.getString("BuildersWand.description")));
             meta.setLore(lore);
+
+            meta.setDisplayName(ChatWriter.addColors(name));
             meta.addItemFlags(ItemFlag.HIDE_DESTROYS);
             wand.setItemMeta(meta);
         }
 
         NBTTagList list = new NBTTagList();
         list.add(new NBTTagString("minecraft:air"));
+
         modManager.setNBTTag(wand, "CanDestroy", list);
         modManager.setNBTTag(wand, "IdentifierBuilderswand", new NBTTagInt(0));
+
         return wand;
     }
 
@@ -145,6 +151,7 @@ public class BuildersWandListener implements Listener {
 
             // TODO: Make safe
             newRecipe.shape(top, middle, bottom); //makes recipe
+
             for (String key : materials.getKeys(false)) {
                 newRecipe.setIngredient(key.charAt(0), Material.getMaterial(materials.getString(key)));
             }
@@ -164,6 +171,7 @@ public class BuildersWandListener implements Listener {
 
             // TODO: Make safe
             newRecipe.shape(top, middle, bottom); //makes recipe
+
             for (String key : materials.getKeys(false)) {
                 newRecipe.setIngredient(key.charAt(0), Material.getMaterial(materials.getString(key)));
             }
@@ -183,6 +191,7 @@ public class BuildersWandListener implements Listener {
 
             // TODO: Make safe
             newRecipe.shape(top, middle, bottom); //makes recipe
+
             for (String key : materials.getKeys(false)) {
                 newRecipe.setIngredient(key.charAt(0), Material.getMaterial(materials.getString(key)));
             }
@@ -202,6 +211,7 @@ public class BuildersWandListener implements Listener {
 
             // TODO: Make safe
             newRecipe.shape(top, middle, bottom); //makes recipe
+
             for (String key : materials.getKeys(false)) {
                 newRecipe.setIngredient(key.charAt(0), Material.getMaterial(materials.getString(key)));
             }
@@ -221,6 +231,7 @@ public class BuildersWandListener implements Listener {
 
             // TODO: Make safe
             newRecipe.shape(top, middle, bottom); //makes recipe
+
             for (String key : materials.getKeys(false)) {
                 newRecipe.setIngredient(key.charAt(0), Material.getMaterial(materials.getString(key)));
             }
@@ -232,9 +243,8 @@ public class BuildersWandListener implements Listener {
     }
 
     @SuppressWarnings("deprecation")
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
     public void onClick (PlayerInteractEvent e) {
-        if (e.isCancelled()) return;
         if (Lists.WORLDS_BUILDERSWANDS.contains(e.getPlayer().getWorld().getName())) return;
 
         ItemStack wand = e.getPlayer().getInventory().getItemInMainHand();
@@ -248,7 +258,9 @@ public class BuildersWandListener implements Listener {
 
         int _u = 0;
         int _w = 0;
+
         Player p = e.getPlayer();
+
         if (!p.isSneaking()) {
             switch (wand.getType()) {  //TODO: custom Builderswand sizes
                 case STONE_SHOVEL:
@@ -273,15 +285,18 @@ public class BuildersWandListener implements Listener {
         Block b = e.getClickedBlock();
         BlockFace bf = e.getBlockFace();
         ItemStack[] inv = p.getInventory().getContents();
+
         Vector u = new Vector(0, 0, 0);
         Vector v = new Vector(0, 0, 0);
         Vector w = new Vector(0, 0, 0);
+
         if (bf.equals(BlockFace.UP) || bf.equals(BlockFace.DOWN)) {
             if (bf.equals(BlockFace.UP)) {
                 v = new Vector(0, 1, 0);
             } else {
                 v = new Vector(0, -1, 0);
             }
+
             switch (PlayerInfo.getFacingDirection(p)) {
                 case "N":
                     w = new Vector(-1, 0, 0);
@@ -296,6 +311,7 @@ public class BuildersWandListener implements Listener {
                     w = new Vector(0, 0, 1);
                     break;
             }
+
             u = v.getCrossProduct(w);
         } else if (bf.equals(BlockFace.NORTH)) {
             v = new Vector(0, 0, -1);
@@ -324,9 +340,12 @@ public class BuildersWandListener implements Listener {
                 for (int i = -_w; i <= _w; i++) {
                     for (int j = -_u; j <= _u; j++) {
                         Location l = b.getLocation().clone();
+
                         l.subtract(w.clone().multiply(i));
                         l.subtract(u.clone().multiply(j));
+
                         Location loc = l.clone().subtract(v.clone().multiply(-1));
+
                         if (b.getWorld().getBlockAt(l).getType().equals(b.getType())) {
                             if (b.getWorld().getBlockAt(loc).getType().equals(Material.AIR) ||
                                     b.getWorld().getBlockAt(loc).getType().equals(Material.CAVE_AIR) ||
@@ -349,15 +368,19 @@ public class BuildersWandListener implements Listener {
                                 Block nb = b.getWorld().getBlockAt(loc);
                                 nb.setType(current.getType());
                                 BlockData bd = nb.getBlockData();
+
                                 if (bd instanceof Directional) {
                                     ((Directional) bd).setFacing(((Directional) nb.getWorld().getBlockAt(loc.subtract(v)).getBlockData()).getFacing());
                                 }
+
                                 nb.setBlockData(bd);
 
                                 current.setAmount(current.getAmount() - 1);
+
                                 if (config.getBoolean("BuildersWand.useDurability")) { //TODO: Add Modifiers to the Builderwand (Self-Repair, Reinforced, XP)
                                     wand.setDurability((short) (wand.getDurability() + 1));
                                 }
+
                                 if (current.getAmount() == 0) { //TODO: Add Exp gain for Builderswands
                                     break loop;
                                 }
@@ -373,9 +396,12 @@ public class BuildersWandListener implements Listener {
             for (int i = -_w; i <= _w; i++) {
                 for (int j = -_u; j <= _u; j++) {
                     Location l = b.getLocation().clone();
+
                     l.subtract(w.clone().multiply(i));
                     l.subtract(u.clone().multiply(j));
+
                     Location loc = l.clone().subtract(v.clone().multiply(-1));
+
                     if (b.getWorld().getBlockAt(l).getType().equals(b.getType())) {
                         if (b.getWorld().getBlockAt(loc).getType().equals(Material.AIR) ||
                                 b.getWorld().getBlockAt(loc).getType().equals(Material.CAVE_AIR) ||
@@ -395,9 +421,11 @@ public class BuildersWandListener implements Listener {
                             Block nb = b.getWorld().getBlockAt(loc);
                             nb.setType(b.getType());
                             BlockData bd = nb.getBlockData();
+
                             if (bd instanceof Directional) {
                                 ((Directional) bd).setFacing(((Directional) nb.getWorld().getBlockAt(loc.subtract(v)).getBlockData()).getFacing());
                             }
+
                             nb.setBlockData(bd);
                             e.setCancelled(true);
                         }

--- a/src/main/java/de/flo56958/MineTinker/Listeners/BuildersWandListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/BuildersWandListener.java
@@ -114,12 +114,15 @@ public class BuildersWandListener implements Listener {
     private static ItemStack buildersWandCreator(Material m, String name) { //TODO: Modify to implement Modifiers
         ItemStack wand = new ItemStack(m, 1);
         ItemMeta meta = wand.getItemMeta();
-        ArrayList<String> lore = new ArrayList<>();
-        meta.setDisplayName(ChatWriter.addColors(name));
-        lore.add(ChatWriter.addColors(config.getString("BuildersWand.description")));
-        meta.setLore(lore);
-        meta.addItemFlags(ItemFlag.HIDE_DESTROYS);
-        wand.setItemMeta(meta);
+
+        if (meta != null) {
+            ArrayList<String> lore = new ArrayList<>();
+            meta.setDisplayName(ChatWriter.addColors(name));
+            lore.add(ChatWriter.addColors(config.getString("BuildersWand.description")));
+            meta.setLore(lore);
+            meta.addItemFlags(ItemFlag.HIDE_DESTROYS);
+            wand.setItemMeta(meta);
+        }
 
         NBTTagList list = new NBTTagList();
         list.add(new NBTTagString("minecraft:air"));
@@ -139,10 +142,13 @@ public class BuildersWandListener implements Listener {
             String middle = config.getString("BuildersWand.Recipes.Wood.Middle");
             String bottom = config.getString("BuildersWand.Recipes.Wood.Bottom");
             ConfigurationSection materials = config.getConfigurationSection("BuildersWand.Recipes.Wood.Materials");
+
+            // TODO: Make safe
             newRecipe.shape(top, middle, bottom); //makes recipe
             for (String key : materials.getKeys(false)) {
                 newRecipe.setIngredient(key.charAt(0), Material.getMaterial(materials.getString(key)));
             }
+
             Main.getPlugin().getServer().addRecipe(newRecipe); //adds recipe
             ModManager.instance().recipe_Namespaces.add(nkey);
         } catch (Exception e) {
@@ -155,10 +161,13 @@ public class BuildersWandListener implements Listener {
             String middle = config.getString("BuildersWand.Recipes.Stone.Middle");
             String bottom = config.getString("BuildersWand.Recipes.Stone.Bottom");
             ConfigurationSection materials = config.getConfigurationSection("BuildersWand.Recipes.Stone.Materials");
+
+            // TODO: Make safe
             newRecipe.shape(top, middle, bottom); //makes recipe
             for (String key : materials.getKeys(false)) {
                 newRecipe.setIngredient(key.charAt(0), Material.getMaterial(materials.getString(key)));
             }
+
             Main.getPlugin().getServer().addRecipe(newRecipe); //adds recipe
             ModManager.instance().recipe_Namespaces.add(nkey);
         } catch (Exception e) {
@@ -171,10 +180,13 @@ public class BuildersWandListener implements Listener {
             String middle = config.getString("BuildersWand.Recipes.Iron.Middle");
             String bottom = config.getString("BuildersWand.Recipes.Iron.Bottom");
             ConfigurationSection materials = config.getConfigurationSection("BuildersWand.Recipes.Iron.Materials");
+
+            // TODO: Make safe
             newRecipe.shape(top, middle, bottom); //makes recipe
             for (String key : materials.getKeys(false)) {
                 newRecipe.setIngredient(key.charAt(0), Material.getMaterial(materials.getString(key)));
             }
+
             Main.getPlugin().getServer().addRecipe(newRecipe); //adds recipe
             ModManager.instance().recipe_Namespaces.add(nkey);
         } catch (Exception e) {
@@ -187,10 +199,13 @@ public class BuildersWandListener implements Listener {
             String middle = config.getString("BuildersWand.Recipes.Gold.Middle");
             String bottom = config.getString("BuildersWand.Recipes.Gold.Bottom");
             ConfigurationSection materials = config.getConfigurationSection("BuildersWand.Recipes.Gold.Materials");
+
+            // TODO: Make safe
             newRecipe.shape(top, middle, bottom); //makes recipe
             for (String key : materials.getKeys(false)) {
                 newRecipe.setIngredient(key.charAt(0), Material.getMaterial(materials.getString(key)));
             }
+
             Main.getPlugin().getServer().addRecipe(newRecipe); //adds recipe
             ModManager.instance().recipe_Namespaces.add(nkey);
         } catch (Exception e) {
@@ -203,10 +218,13 @@ public class BuildersWandListener implements Listener {
             String middle = config.getString("BuildersWand.Recipes.Diamond.Middle");
             String bottom = config.getString("BuildersWand.Recipes.Diamond.Bottom");
             ConfigurationSection materials = config.getConfigurationSection("BuildersWand.Recipes.Diamond.Materials");
+
+            // TODO: Make safe
             newRecipe.shape(top, middle, bottom); //makes recipe
             for (String key : materials.getKeys(false)) {
                 newRecipe.setIngredient(key.charAt(0), Material.getMaterial(materials.getString(key)));
             }
+
             Main.getPlugin().getServer().addRecipe(newRecipe); //adds recipe
         } catch (Exception e) {
             ChatWriter.logError("Could not register recipe for the Diamond Builderswand!"); //executes if the recipe could not initialize
@@ -216,17 +234,17 @@ public class BuildersWandListener implements Listener {
     @SuppressWarnings("deprecation")
 	@EventHandler
     public void onClick (PlayerInteractEvent e) {
-        if (e.isCancelled()) { return; }
-        if (Lists.WORLDS_BUILDERSWANDS.contains(e.getPlayer().getWorld().getName())) { return; }
+        if (e.isCancelled()) return;
+        if (Lists.WORLDS_BUILDERSWANDS.contains(e.getPlayer().getWorld().getName())) return;
 
         ItemStack wand = e.getPlayer().getInventory().getItemInMainHand();
 
-        if (!modManager.isWandViable(wand)) { return; }
+        if (!modManager.isWandViable(wand)) return;
 
         e.setCancelled(true);
 
-        if (!e.getPlayer().hasPermission("minetinker.builderswands.use")) { return; }
-        if (!e.getAction().equals(Action.RIGHT_CLICK_BLOCK)) { return; }
+        if (!e.getPlayer().hasPermission("minetinker.builderswands.use")) return;
+        if (!e.getAction().equals(Action.RIGHT_CLICK_BLOCK)) return;
 
         int _u = 0;
         int _w = 0;
@@ -296,7 +314,7 @@ public class BuildersWandListener implements Listener {
             w = new Vector(0, 0, 1);
             u = new Vector(0, -1, 0);
         }
-        if (p.getGameMode().equals(GameMode.SURVIVAL) || p.getGameMode().equals(GameMode.ADVENTURE)) {
+        if ((p.getGameMode().equals(GameMode.SURVIVAL) || p.getGameMode().equals(GameMode.ADVENTURE)) && b != null) {
             for (ItemStack current : inv) {
                 if (current == null) { continue; }
                 if (!current.getType().equals(b.getType())) { continue; }
@@ -351,7 +369,7 @@ public class BuildersWandListener implements Listener {
                 }
                 break;
             }
-        } else if (p.getGameMode().equals(GameMode.CREATIVE)) {
+        } else if (p.getGameMode().equals(GameMode.CREATIVE) && b != null) {
             for (int i = -_w; i <= _w; i++) {
                 for (int j = -_u; j <= _u; j++) {
                     Location l = b.getLocation().clone();

--- a/src/main/java/de/flo56958/MineTinker/Listeners/ConvertListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/ConvertListener.java
@@ -52,6 +52,7 @@ public class ConvertListener implements Listener{
 	public void PrepareCraft(PrepareItemCraftEvent e) {
 		if (e.getRecipe() != null) {
 			Player player = null;
+
 			for (HumanEntity humans : e.getViewers()) {
 				if (humans instanceof Player) { player = (Player) humans; }
 			}
@@ -64,20 +65,22 @@ public class ConvertListener implements Listener{
 	        
 	        if (currentItem != null) {
 	        	ItemMeta m = currentItem.getItemMeta();
+
 	        	if (m != null) {
 	        		if (modManager.isWandViable(currentItem)) {
 	        			return;
 	        		}
 	        	}
+
 	        	modManager.convertItemStack(currentItem);
 	        }
 		}
 	}
 	
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
     public void onCraft(CraftItemEvent e) {
-        if (e.isCancelled()) return;
         if (!(e.getWhoClicked() instanceof Player)) return;
+
         Player player = (Player) e.getWhoClicked();
         
         if (config.getBoolean("Sound.OnEveryCrafting")) {

--- a/src/main/java/de/flo56958/MineTinker/Listeners/ConvertListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/ConvertListener.java
@@ -41,7 +41,7 @@ public class ConvertListener implements Listener{
 		converting.addAll(ToolType.BOOTS.getMaterials());
 		converting.addAll(ToolType.BOW.getMaterials());
 	    
-	    for(Material m : converting) {
+	    for (Material m : converting) {
 	    	ShapelessRecipe recipe = new ShapelessRecipe(new NamespacedKey(Main.getPlugin(), m.toString() + "_Converter"), new ItemStack(m, 1));
 			recipe.addIngredient(m);
 			Bukkit.addRecipe(recipe);
@@ -56,16 +56,16 @@ public class ConvertListener implements Listener{
 				if (humans instanceof Player) { player = (Player) humans; }
 			}
 			
-			if (player == null) { return; }
-	        if (!player.hasPermission("minetinker.tool.create")) { return; }
-	        if (Lists.WORLDS.contains(player.getWorld().getName())) { return; }
+			if (player == null) return;
+	        if (!player.hasPermission("minetinker.tool.create")) return;
+	        if (Lists.WORLDS.contains(player.getWorld().getName())) return;
 
 	        ItemStack currentItem = e.getInventory().getResult();
 	        
-	        if(currentItem != null) {
+	        if (currentItem != null) {
 	        	ItemMeta m = currentItem.getItemMeta();
-	        	if(m != null) {
-	        		if(modManager.isWandViable(currentItem)) {
+	        	if (m != null) {
+	        		if (modManager.isWandViable(currentItem)) {
 	        			return;
 	        		}
 	        	}
@@ -76,8 +76,8 @@ public class ConvertListener implements Listener{
 	
 	@EventHandler
     public void onCraft(CraftItemEvent e) {
-        if (e.isCancelled()) { return; }
-        if (!(e.getWhoClicked() instanceof Player)) { return; }
+        if (e.isCancelled()) return;
+        if (!(e.getWhoClicked() instanceof Player)) return;
         Player player = (Player) e.getWhoClicked();
         
         if (config.getBoolean("Sound.OnEveryCrafting")) {
@@ -87,12 +87,14 @@ public class ConvertListener implements Listener{
         
         ItemStack tool = e.getInventory().getResult();
         
-        if (!(modManager.isToolViable(tool) || modManager.isArmorViable(tool) || modManager.isWandViable(tool))) { return; }
+        if (!(modManager.isToolViable(tool) || modManager.isArmorViable(tool) || modManager.isWandViable(tool))) return;
 
         if (config.getBoolean("Sound.OnCrafting")) {
 			player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1.0F, 0.5F);
 		}
 
-        ChatWriter.log(false, player.getName() + " crafted " + ItemGenerator.getDisplayName(tool) + "! It is now a MineTinker-Item!");
+        if (tool != null) {
+			ChatWriter.log(false, player.getName() + " crafted " + ItemGenerator.getDisplayName(tool) + "! It is now a MineTinker-Item!");
+		}
     }
 }

--- a/src/main/java/de/flo56958/MineTinker/Listeners/ConvertListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/ConvertListener.java
@@ -50,31 +50,48 @@ public class ConvertListener implements Listener{
 	
 	@EventHandler
 	public void PrepareCraft(PrepareItemCraftEvent e) {
-		if (e.getRecipe() != null) {
-			Player player = null;
+		if (e.getRecipe() == null) return;
 
-			for (HumanEntity humans : e.getViewers()) {
-				if (humans instanceof Player) { player = (Player) humans; }
-			}
-			
-			if (player == null) return;
-	        if (!player.hasPermission("minetinker.tool.create")) return;
-	        if (Lists.WORLDS.contains(player.getWorld().getName())) return;
+		Player player = null;
 
-	        ItemStack currentItem = e.getInventory().getResult();
-	        
-	        if (currentItem != null) {
-	        	ItemMeta m = currentItem.getItemMeta();
-
-	        	if (m != null) {
-	        		if (modManager.isWandViable(currentItem)) {
-	        			return;
-	        		}
-	        	}
-
-	        	modManager.convertItemStack(currentItem);
-	        }
+		for (HumanEntity humans : e.getViewers()) {
+			if (humans instanceof Player) { player = (Player) humans; }
 		}
+
+		if (player == null) return;
+		if (!player.hasPermission("minetinker.tool.create")) return;
+		if (Lists.WORLDS.contains(player.getWorld().getName())) return;
+
+		ItemStack currentItem = e.getInventory().getResult();
+
+		if (currentItem == null) return;
+
+		int actualItems = 0;
+		ItemStack lastItem = null;
+
+		for (ItemStack item : e.getInventory().getMatrix()) {
+			if (item != null && item.getType() != Material.AIR) {
+				actualItems++;
+				lastItem = item;
+			}
+		}
+
+		if (lastItem != null && actualItems == 1 && currentItem.getType() == lastItem.getType()) {
+			if (modManager.isArmorViable(lastItem) || modManager.isToolViable(lastItem) || modManager.isWandViable(lastItem)) {
+				e.getInventory().setResult(new ItemStack(Material.AIR, 1));
+				return;
+			}
+		}
+
+		ItemMeta m = currentItem.getItemMeta();
+
+		if (m != null) {
+			if (modManager.isWandViable(currentItem)) {
+				return;
+			}
+		}
+
+		modManager.convertItemStack(currentItem);
 	}
 	
 	@EventHandler(ignoreCancelled = true)

--- a/src/main/java/de/flo56958/MineTinker/Listeners/EasyHarvestListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/EasyHarvestListener.java
@@ -35,10 +35,9 @@ public class EasyHarvestListener implements Listener {
         if (!(p.getGameMode().equals(GameMode.SURVIVAL) || p.getGameMode().equals(GameMode.ADVENTURE))) return;
 
         ItemStack tool = p.getInventory().getItemInMainHand();
+
         if (!ToolType.HOE.getMaterials().contains(tool.getType())) return;
-
         if (!modManager.isToolViable(tool)) return;
-
         if (e.getClickedBlock() == null) return;
         if (e.getItem() == null) return;
 
@@ -50,12 +49,14 @@ public class EasyHarvestListener implements Listener {
         if (!placeEvent.canBuild() || placeEvent.isCancelled()) return;
 
         Block b = e.getClickedBlock();
+
         if (b.getState().getData() instanceof Crops) { harvestCrops(p, tool, b); }
         if (b.getState().getData() instanceof NetherWarts) { harvestWarts(p, tool, b); }
     }
 
     private static void harvestWarts(Player p, ItemStack tool, Block b) {
         NetherWarts w = (NetherWarts) b.getState().getData();
+
         if (w.getState().equals(NetherWartsState.RIPE)) {
             breakWarts(p, tool, b);
             playSound(b);
@@ -68,10 +69,13 @@ public class EasyHarvestListener implements Listener {
 
         if (modManager.get(ModifierType.POWER) != null) {
             if (modManager.hasMod(tool, modManager.get(ModifierType.POWER)) && !p.isSneaking()) {
+
                 int level = modManager.getModLevel(tool, modManager.get(ModifierType.POWER));
+
                 if (level == 1) {
                     Block b1;
                     Block b2;
+
                     if (PlayerInfo.getFacingDirection(p).equals("N") || PlayerInfo.getFacingDirection(p).equals("S")) {
                         if (config.getBoolean("Modifiers.Power.lv1_vertical")) {
                             b1 = b.getWorld().getBlockAt(b.getLocation().add(0, 0, 1));
@@ -91,10 +95,12 @@ public class EasyHarvestListener implements Listener {
                     } else {
                         return;
                     }
+
                     if (b1.getType().equals(b.getType()) && ((NetherWarts) b1.getState().getData()).getState().equals(NetherWartsState.RIPE)) {
                         breakBlock(b1, p);
                         replantCrops(p, b1, m);
                     }
+
                     if (b2.getType().equals(b.getType()) && ((NetherWarts) b2.getState().getData()).getState().equals(NetherWartsState.RIPE)) {
                         breakBlock(b2, p);
                         replantCrops(p, b2, m);
@@ -104,6 +110,7 @@ public class EasyHarvestListener implements Listener {
                         for (int z = -(level - 1); z <= (level - 1); z++) {
                             if (!(x == 0 && z == 0)) {
                                 Block b1 = b.getWorld().getBlockAt(b.getLocation().add(x, 0, z));
+
                                 if (b1.getType().equals(b.getType()) && ((NetherWarts) b1.getState().getData()).getState().equals(NetherWartsState.RIPE)) {
                                     breakBlock(b1, p);
                                     replantCrops(p, b1, m);
@@ -133,12 +140,14 @@ public class EasyHarvestListener implements Listener {
     private static void breakCrops(Player p, ItemStack tool, Block b) {
         Power.HASPOWER.put(p, true);
         Material m = b.getType();
+
         if (modManager.get(ModifierType.POWER) != null) {
             if (modManager.hasMod(tool, modManager.get(ModifierType.POWER)) && !p.isSneaking()) {
                 int level = modManager.getModLevel(tool, modManager.get(ModifierType.POWER));
                 if (level == 1) {
                     Block b1;
                     Block b2;
+
                     if (PlayerInfo.getFacingDirection(p).equals("N") || PlayerInfo.getFacingDirection(p).equals("S")) {
                         if (config.getBoolean("Modifiers.Power.lv1_vertical")) {
                             b1 = b.getWorld().getBlockAt(b.getLocation().add(0, 0, 1));
@@ -158,10 +167,12 @@ public class EasyHarvestListener implements Listener {
                     } else {
                         return;
                     }
+
                     if (b1.getType().equals(b.getType()) && ((Crops) b1.getState().getData()).getState().equals(CropState.RIPE)) {
                         breakBlock(b1, p);
                         replantCrops(p, b1, m);
                     }
+
                     if (b2.getType().equals(b.getType()) && ((Crops) b2.getState().getData()).getState().equals(CropState.RIPE)) {
                         breakBlock(b2, p);
                         replantCrops(p, b2, m);
@@ -171,6 +182,7 @@ public class EasyHarvestListener implements Listener {
                         for (int z = -(level - 1); z <= (level - 1); z++) {
                             if (!(x == 0 && z == 0)) {
                                 Block b1 = b.getWorld().getBlockAt(b.getLocation().add(x, 0, z));
+
                                 if (b1.getType().equals(b.getType()) && ((Crops) b1.getState().getData()).getState().equals(CropState.RIPE)) {
                                     breakBlock(b1, p);
                                     replantCrops(p, b1, m);

--- a/src/main/java/de/flo56958/MineTinker/Listeners/EasyHarvestListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/EasyHarvestListener.java
@@ -7,15 +7,14 @@ import de.flo56958.MineTinker.Modifiers.ModManager;
 import de.flo56958.MineTinker.Modifiers.Types.ModifierType;
 import de.flo56958.MineTinker.Modifiers.Types.Power;
 import de.flo56958.MineTinker.Utilities.PlayerInfo;
-import net.minecraft.server.v1_14_R1.BlockPosition;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.craftbukkit.v1_14_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
@@ -93,11 +92,11 @@ public class EasyHarvestListener implements Listener {
                         return;
                     }
                     if (b1.getType().equals(b.getType()) && ((NetherWarts) b1.getState().getData()).getState().equals(NetherWartsState.RIPE)) {
-                        ((CraftPlayer) p).getHandle().playerInteractManager.breakBlock(new BlockPosition(b1.getX(), b1.getY(), b1.getZ()));
+                        breakBlock(b1, p);
                         replantCrops(p, b1, m);
                     }
                     if (b2.getType().equals(b.getType()) && ((NetherWarts) b2.getState().getData()).getState().equals(NetherWartsState.RIPE)) {
-                        ((CraftPlayer) p).getHandle().playerInteractManager.breakBlock(new BlockPosition(b2.getX(), b2.getY(), b2.getZ()));
+                        breakBlock(b2, p);
                         replantCrops(p, b2, m);
                     }
                 } else {
@@ -106,7 +105,7 @@ public class EasyHarvestListener implements Listener {
                             if (!(x == 0 && z == 0)) {
                                 Block b1 = b.getWorld().getBlockAt(b.getLocation().add(x, 0, z));
                                 if (b1.getType().equals(b.getType()) && ((NetherWarts) b1.getState().getData()).getState().equals(NetherWartsState.RIPE)) {
-                                    ((CraftPlayer) p).getHandle().playerInteractManager.breakBlock(new BlockPosition(b1.getX(), b1.getY(), b1.getZ()));
+                                    breakBlock(b1, p);
                                     replantCrops(p, b1, m);
                                 }
                             }
@@ -116,7 +115,7 @@ public class EasyHarvestListener implements Listener {
             }
         }
 
-        ((CraftPlayer) p).getHandle().playerInteractManager.breakBlock(new BlockPosition(b.getX(), b.getY(), b.getZ()));
+        breakBlock(b, p);
         replantCrops(p, b, m);
 
         Power.HASPOWER.put(p, false);
@@ -160,11 +159,11 @@ public class EasyHarvestListener implements Listener {
                         return;
                     }
                     if (b1.getType().equals(b.getType()) && ((Crops) b1.getState().getData()).getState().equals(CropState.RIPE)) {
-                        ((CraftPlayer) p).getHandle().playerInteractManager.breakBlock(new BlockPosition(b1.getX(), b1.getY(), b1.getZ()));
+                        breakBlock(b1, p);
                         replantCrops(p, b1, m);
                     }
                     if (b2.getType().equals(b.getType()) && ((Crops) b2.getState().getData()).getState().equals(CropState.RIPE)) {
-                        ((CraftPlayer) p).getHandle().playerInteractManager.breakBlock(new BlockPosition(b2.getX(), b2.getY(), b2.getZ()));
+                        breakBlock(b2, p);
                         replantCrops(p, b2, m);
                     }
                 } else {
@@ -173,7 +172,7 @@ public class EasyHarvestListener implements Listener {
                             if (!(x == 0 && z == 0)) {
                                 Block b1 = b.getWorld().getBlockAt(b.getLocation().add(x, 0, z));
                                 if (b1.getType().equals(b.getType()) && ((Crops) b1.getState().getData()).getState().equals(CropState.RIPE)) {
-                                    ((CraftPlayer) p).getHandle().playerInteractManager.breakBlock(new BlockPosition(b1.getX(), b1.getY(), b1.getZ()));
+                                    breakBlock(b1, p);
                                     replantCrops(p, b1, m);
                                 }
                             }
@@ -183,7 +182,7 @@ public class EasyHarvestListener implements Listener {
             }
         }
 
-        ((CraftPlayer) p).getHandle().playerInteractManager.breakBlock(new BlockPosition(b.getX(), b.getY(), b.getZ()));
+        breakBlock(b, p);
         replantCrops(p, b, m);
 
         Power.HASPOWER.put(p, false);
@@ -221,5 +220,12 @@ public class EasyHarvestListener implements Listener {
         if (config.getBoolean("EasyHarvest.Sound")) {
             b.getWorld().playSound(b.getLocation(), Sound.ITEM_HOE_TILL, 1.0F, 0.5F);
         }
+    }
+
+    private static void breakBlock(Block b, Player p) {
+        BlockBreakEvent event = new BlockBreakEvent(b, p);
+        Bukkit.getServer().getPluginManager().callEvent(event);
+
+        if (!event.isCancelled()) b.breakNaturally(p.getInventory().getItemInMainHand());
     }
 }

--- a/src/main/java/de/flo56958/MineTinker/Listeners/EasyHarvestListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/EasyHarvestListener.java
@@ -29,23 +29,26 @@ public class EasyHarvestListener implements Listener {
 
     @EventHandler
     public void onHarvestTry(PlayerInteractEvent e) {
-        if (!e.getAction().equals(Action.RIGHT_CLICK_BLOCK)) { return; }
+        if (!e.getAction().equals(Action.RIGHT_CLICK_BLOCK)) return;
         Player p = e.getPlayer();
 
-        if (Lists.WORLDS_EASYHARVEST.contains(p.getWorld().getName())) { return; }
-        if (!(p.getGameMode().equals(GameMode.SURVIVAL) || p.getGameMode().equals(GameMode.ADVENTURE))) { return; }
+        if (Lists.WORLDS_EASYHARVEST.contains(p.getWorld().getName())) return;
+        if (!(p.getGameMode().equals(GameMode.SURVIVAL) || p.getGameMode().equals(GameMode.ADVENTURE))) return;
 
         ItemStack tool = p.getInventory().getItemInMainHand();
-        if (!ToolType.HOE.getMaterials().contains(tool.getType())) { return; }
+        if (!ToolType.HOE.getMaterials().contains(tool.getType())) return;
 
-        if (!modManager.isToolViable(tool)) { return; }
+        if (!modManager.isToolViable(tool)) return;
+
+        if (e.getClickedBlock() == null) return;
+        if (e.getItem() == null) return;
 
         //triggers a pseudoevent to find out if the Player can build
         BlockPlaceEvent placeEvent = new BlockPlaceEvent(e.getClickedBlock(), e.getClickedBlock().getState(), e.getClickedBlock(), e.getItem(), p, true);
         Bukkit.getPluginManager().callEvent(placeEvent);
 
         //check the pseudoevent
-        if (!placeEvent.canBuild() || placeEvent.isCancelled()) { return; }
+        if (!placeEvent.canBuild() || placeEvent.isCancelled()) return;
 
         Block b = e.getClickedBlock();
         if (b.getState().getData() instanceof Crops) { harvestCrops(p, tool, b); }
@@ -189,8 +192,6 @@ public class EasyHarvestListener implements Listener {
     private static void replantCrops(Player p, Block b, Material m) {
         if (config.getBoolean("EasyHarvest.replant")) {
             for (ItemStack is : p.getInventory().getContents()) {
-                if (is == null) { continue; }
-
                 if (m.equals(Material.BEETROOTS) && is.getType().equals(Material.BEETROOT_SEEDS)) {
                     is.setAmount(is.getAmount() - 1);
                     b.setType(m);

--- a/src/main/java/de/flo56958/MineTinker/Listeners/ElevatorListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/ElevatorListener.java
@@ -49,15 +49,13 @@ public class ElevatorListener implements Listener {
     @SuppressWarnings("EmptyMethod")
     public static void init() {/*class must be called once*/}
     
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onSneak (PlayerToggleSneakEvent e) {
-        if (e.isCancelled()) return;
-
         if (Lists.WORLDS_ELEVATOR.contains(e.getPlayer().getWorld().getName())) return;
-
         if (!e.isSneaking()) return;
 
         Player p = e.getPlayer();
+
         if (!p.hasPermission("minetinker.elevator.use")) return;
 
         Location l = p.getLocation();
@@ -72,25 +70,29 @@ public class ElevatorListener implements Listener {
         for (int i = l.getBlockY() - 1; i >= 0; i--) {
             if (p.getWorld().getBlockAt(l.getBlockX(), i, l.getBlockZ()).getState() instanceof Hopper) {
                 Hopper h2 = (Hopper) p.getWorld().getBlockAt(l.getBlockX(), i, l.getBlockZ()).getState();
+
                 if (h2.getCustomName() == null) { continue; } //name could be NULL
+
                 if (h2.getCustomName().equals(ChatColor.GRAY + config.getString("Elevator.name"))) {
                     l.add(0, i - l.getBlockY() + 2, 0);
                     p.teleport(l);
+
                     if (config.getBoolean("Elevator.Sound")) {
                         p.playSound(p.getLocation(), Sound.BLOCK_CHEST_CLOSE, 0.5F, 0.5F);
                     }
+
                     break;
                 }
             }
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onJump (PlayerMoveEvent e) {
-        if (e.isCancelled()) return;
         if (Lists.WORLDS_ELEVATOR.contains(e.getPlayer().getWorld().getName())) return;
 
         Player p = e.getPlayer();
+
         if (!p.hasPermission("minetinker.elevator.use")) return;
         if (e.getTo() == null) return;
 
@@ -103,17 +105,22 @@ public class ElevatorListener implements Listener {
 
         Hopper h1 = (Hopper) b.getState();
         if (h1.getCustomName() == null) return;
+
         if (h1.getCustomName().equals(ChatColor.GRAY + config.getString("Elevator.name"))) {
             for (int i = l.getBlockY() + 1; i <= 256; i++) {
                 if (p.getWorld().getBlockAt(l.getBlockX(), i, l.getBlockZ()).getState() instanceof Hopper) {
                     Hopper h2 = (Hopper) p.getWorld().getBlockAt(l.getBlockX(), i, l.getBlockZ()).getState();
+
                     if (h2.getCustomName() == null) { continue; }
+
                     if (h2.getCustomName().equals(ChatColor.GRAY + config.getString("Elevator.name"))) {
                         l.add(0, i - l.getBlockY() + 2, 0);
                         p.teleport(l);
+
                         if (config.getBoolean("Elevator.Sound")) {
                             p.playSound(p.getLocation(), Sound.BLOCK_CHEST_OPEN, 0.5F, 0.5F);
                         }
+
                         break;
                     }
                 }

--- a/src/main/java/de/flo56958/MineTinker/Listeners/ElevatorListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/ElevatorListener.java
@@ -51,23 +51,23 @@ public class ElevatorListener implements Listener {
     
     @EventHandler
     public void onSneak (PlayerToggleSneakEvent e) {
-        if (e.isCancelled()) { return; }
+        if (e.isCancelled()) return;
 
-        if (Lists.WORLDS_ELEVATOR.contains(e.getPlayer().getWorld().getName())) { return; }
+        if (Lists.WORLDS_ELEVATOR.contains(e.getPlayer().getWorld().getName())) return;
 
-        if (!e.isSneaking()) { return; }
+        if (!e.isSneaking()) return;
 
         Player p = e.getPlayer();
-        if (!p.hasPermission("minetinker.elevator.use")) { return; }
+        if (!p.hasPermission("minetinker.elevator.use")) return;
 
         Location l = p.getLocation();
 
         Block b = p.getWorld().getBlockAt(l.add(0, -2, 0));
-        if (!(b.getState() instanceof Hopper)) { return; }
+        if (!(b.getState() instanceof Hopper)) return;
 
         Hopper h1 = (Hopper) b.getState();
-        if (h1.getCustomName() == null) { return; } //name could be NULL
-        if (!h1.getCustomName().equals(ChatColor.GRAY + config.getString("Elevator.name"))) { return; }
+        if (h1.getCustomName() == null) return; //name could be NULL
+        if (!h1.getCustomName().equals(ChatColor.GRAY + config.getString("Elevator.name"))) return;
 
         for (int i = l.getBlockY() - 1; i >= 0; i--) {
             if (p.getWorld().getBlockAt(l.getBlockX(), i, l.getBlockZ()).getState() instanceof Hopper) {
@@ -87,21 +87,22 @@ public class ElevatorListener implements Listener {
 
     @EventHandler
     public void onJump (PlayerMoveEvent e) {
-        if (e.isCancelled()) { return; }
-        if (Lists.WORLDS_ELEVATOR.contains(e.getPlayer().getWorld().getName())) { return; }
+        if (e.isCancelled()) return;
+        if (Lists.WORLDS_ELEVATOR.contains(e.getPlayer().getWorld().getName())) return;
 
         Player p = e.getPlayer();
-        if (!p.hasPermission("minetinker.elevator.use")) { return; }
+        if (!p.hasPermission("minetinker.elevator.use")) return;
+        if (e.getTo() == null) return;
 
         Location l = p.getLocation();
 
-        if (!(e.getTo().getY() > e.getFrom().getY() && e.getTo().getX() == e.getFrom().getX() && e.getTo().getZ() == e.getFrom().getZ())) { return; }
+        if (!(e.getTo().getY() > e.getFrom().getY() && e.getTo().getX() == e.getFrom().getX() && e.getTo().getZ() == e.getFrom().getZ())) return;
 
         Block b = p.getWorld().getBlockAt(l.add(0, -2, 0));
-        if (!(b.getState() instanceof Hopper)) { return; }
+        if (!(b.getState() instanceof Hopper)) return;
 
         Hopper h1 = (Hopper) b.getState();
-        if (h1.getCustomName() == null) { return; }
+        if (h1.getCustomName() == null) return;
         if (h1.getCustomName().equals(ChatColor.GRAY + config.getString("Elevator.name"))) {
             for (int i = l.getBlockY() + 1; i <= 256; i++) {
                 if (p.getWorld().getBlockAt(l.getBlockX(), i, l.getBlockZ()).getState() instanceof Hopper) {

--- a/src/main/java/de/flo56958/MineTinker/Listeners/EnchantingTableListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/EnchantingTableListener.java
@@ -11,11 +11,12 @@ public class EnchantingTableListener implements Listener {
 
     private static final ModManager modManager = ModManager.instance();
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onEnchant(EnchantItemEvent e) {
-        if (e.isCancelled() || Lists.WORLDS.contains(e.getEnchanter().getWorld().getName())) return;
+        if (Lists.WORLDS.contains(e.getEnchanter().getWorld().getName())) return;
 
         ItemStack tool = e.getItem();
+
         if (modManager.isToolViable(tool) || modManager.isWandViable(tool) || modManager.isArmorViable(tool)) e.setCancelled(true);
     }
 }

--- a/src/main/java/de/flo56958/MineTinker/Listeners/EntityListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/EntityListener.java
@@ -147,6 +147,7 @@ public class EntityListener implements Listener {
 
             if (mod != null && mod.getModItem().getType() == Material.ARROW) {
                 e.setCancelled(true);
+                player.updateInventory();
                 return;
             }
         }
@@ -157,6 +158,7 @@ public class EntityListener implements Listener {
 
                 if (mod != null && mod.getModItem().getType() == Material.ARROW) {
                     e.setCancelled(true);
+                    player.updateInventory();
                     return;
                 }
 

--- a/src/main/java/de/flo56958/MineTinker/Listeners/EntityListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/EntityListener.java
@@ -128,15 +128,24 @@ public class EntityListener implements Listener {
     }
 
 	@EventHandler(ignoreCancelled = true)
-    public void onBowFire(ProjectileLaunchEvent e) {
+    public void onProjectileLaunch(ProjectileLaunchEvent e) {
         if (!(e.getEntity().getShooter() instanceof Player)) return;
 
         Player p = (Player) e.getEntity().getShooter();
         ItemStack tool = p.getInventory().getItemInMainHand();
 
+        // This isn't the best detection, if the player has a non modifier in one hand and
+        // one in the other, this won't know which was actually thrown.
+        // Maybe improve this before release.
+        // It works as a safeguard in general though.
+        if (modManager.isModifierItem(tool) || modManager.isModifierItem(p.getInventory().getItemInOffHand())) {
+            e.setCancelled(true);
+            p.updateInventory();
+            p.setCooldown(Material.ENDER_PEARL, 10);
+        }
+
         if (!modManager.isToolViable(tool)) return;
         if (!modManager.durabilityCheck(e, p, tool)) return;
-
 
         modManager.addExp(p, tool, config.getInt("ExpPerArrowShot"));
 

--- a/src/main/java/de/flo56958/MineTinker/Listeners/EntityListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/EntityListener.java
@@ -135,7 +135,7 @@ public class EntityListener implements Listener {
          */
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onBowShoot(EntityShootBowEvent e) {
         if (!(e.getEntity() instanceof Player)) return;
 
@@ -152,9 +152,11 @@ public class EntityListener implements Listener {
             }
         }
 
-        for (ItemStack item : player.getInventory().getStorageContents()) {
+        for (ItemStack item : player.getInventory().getContents()) {
+            if (item == null) continue;
+
             if (item.getType() == Material.ARROW) {
-                Modifier mod = modManager.getModifierFromItem(offHand);
+                Modifier mod = modManager.getModifierFromItem(item);
 
                 if (mod != null && mod.getModItem().getType() == Material.ARROW) {
                     e.setCancelled(true);

--- a/src/main/java/de/flo56958/MineTinker/Listeners/EntityListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/EntityListener.java
@@ -7,17 +7,21 @@ import de.flo56958.MineTinker.Events.MTEntityDeathEvent;
 import de.flo56958.MineTinker.Events.MTProjectileHitEvent;
 import de.flo56958.MineTinker.Main;
 import de.flo56958.MineTinker.Modifiers.ModManager;
+import de.flo56958.MineTinker.Modifiers.Modifier;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
 import org.bukkit.entity.Trident;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
 import org.bukkit.inventory.ItemStack;
@@ -129,5 +133,35 @@ public class EntityListener implements Listener {
         /*
         Self-Repair and Experienced will no longer trigger on bowfire
          */
+    }
+
+    @EventHandler
+    public void onBowShoot(EntityShootBowEvent e) {
+        if (!(e.getEntity() instanceof Player)) return;
+
+        Player player = (Player) e.getEntity();
+        ItemStack offHand = player.getInventory().getItemInOffHand();
+
+        if (offHand.getType() == Material.ARROW) {
+            Modifier mod = modManager.getModifierFromItem(offHand);
+
+            if (mod != null && mod.getModItem().getType() == Material.ARROW) {
+                e.setCancelled(true);
+                return;
+            }
+        }
+
+        for (ItemStack item : player.getInventory().getStorageContents()) {
+            if (item.getType() == Material.ARROW) {
+                Modifier mod = modManager.getModifierFromItem(offHand);
+
+                if (mod != null && mod.getModItem().getType() == Material.ARROW) {
+                    e.setCancelled(true);
+                    return;
+                }
+
+                return;
+            }
+        }
     }
 }

--- a/src/main/java/de/flo56958/MineTinker/Listeners/EntityListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/EntityListener.java
@@ -10,6 +10,7 @@ import de.flo56958.MineTinker.Modifiers.ModManager;
 import de.flo56958.MineTinker.Modifiers.Modifier;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.Sound;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.LivingEntity;
@@ -148,6 +149,7 @@ public class EntityListener implements Listener {
             if (mod != null && mod.getModItem().getType() == Material.ARROW) {
                 e.setCancelled(true);
                 player.updateInventory();
+                player.playSound(player.getLocation(), Sound.ITEM_CROSSBOW_LOADING_END, 1.0f, 1.0f);
                 return;
             }
         }
@@ -161,6 +163,7 @@ public class EntityListener implements Listener {
                 if (mod != null && mod.getModItem().getType() == Material.ARROW) {
                     e.setCancelled(true);
                     player.updateInventory();
+                    player.playSound(player.getLocation(), Sound.ITEM_CROSSBOW_LOADING_END, 1.0f, 1.0f);
                     return;
                 }
 

--- a/src/main/java/de/flo56958/MineTinker/Listeners/EntityListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/EntityListener.java
@@ -30,8 +30,8 @@ public class EntityListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onDamage(EntityDamageByEntityEvent e) {
-        if (e.isCancelled()) { return; }
-        if (Lists.WORLDS.contains(e.getDamager().getWorld().getName())) { return; }
+        if (e.isCancelled()) return;
+        if (Lists.WORLDS.contains(e.getDamager().getWorld().getName())) return;
 
         Player p;
 
@@ -53,21 +53,21 @@ public class EntityListener implements Listener {
             }
         } else if (e.getDamager() instanceof Player) {
             p = (Player) e.getDamager();
-        } else { return; }
+        } else return;
 
         /*
         if (e.getEntity() instanceof Player) {
-            if (((Player) e.getEntity()).isBlocking()) { return; }
+            if (((Player) e.getEntity()).isBlocking()) return;
         } */
 
         ItemStack tool = p.getInventory().getItemInMainHand();
         if (e.getDamager() instanceof Trident) {
             tool = TridentListener.TridentToItemStack.get(e.getDamager());
-            TridentListener.TridentToItemStack.remove(e.getDamager());
-            if (tool == null) { return; }
+            TridentListener.TridentToItemStack.remove((Trident)e.getDamager());
+            if (tool == null) return;
         }
-        if (!modManager.isToolViable(tool)) { return; }
-        if (!modManager.durabilityCheck(e, p, tool)) { return; }
+        if (!modManager.isToolViable(tool)) return;
+        if (!modManager.durabilityCheck(e, p, tool)) return;
 
         int amount = config.getInt("ExpPerEntityHit");
 
@@ -84,11 +84,11 @@ public class EntityListener implements Listener {
     public void onDeath(EntityDeathEvent e) {
         LivingEntity mob = e.getEntity();
         Player p = mob.getKiller();
-        if (p == null) { return; }
-        if (Lists.WORLDS.contains(p.getWorld().getName())) { return; }
+        if (p == null) return;
+        if (Lists.WORLDS.contains(p.getWorld().getName())) return;
         ItemStack tool = p.getInventory().getItemInMainHand();
 
-        if (!modManager.isToolViable(tool)) { return; }
+        if (!modManager.isToolViable(tool)) return;
 
         Bukkit.getPluginManager().callEvent(new MTEntityDeathEvent(p, tool, e));
 
@@ -97,31 +97,31 @@ public class EntityListener implements Listener {
 
     @EventHandler
     public void onArrowHit(ProjectileHitEvent e) {
-        if (!(e.getEntity().getShooter() instanceof Player)) { return; }
+        if (!(e.getEntity().getShooter() instanceof Player)) return;
         Player p = (Player) e.getEntity().getShooter();
         ItemStack tool = p.getInventory().getItemInMainHand();
 
-        if (e.getHitBlock() == null && !ToolType.FISHINGROD.getMaterials().contains(tool.getType())) { return; }
+        if (e.getHitBlock() == null && !ToolType.FISHINGROD.getMaterials().contains(tool.getType())) return;
         if (e.getEntity() instanceof Trident) {
             tool = TridentListener.TridentToItemStack.get(e.getEntity());
-            TridentListener.TridentToItemStack.remove(e.getEntity());
-            if (tool == null) { return; }
+            TridentListener.TridentToItemStack.remove((Trident)e.getEntity());
+            if (tool == null) return;
         }
-        if (!modManager.isToolViable(tool)) { return; }
+        if (!modManager.isToolViable(tool)) return;
 
         Bukkit.getPluginManager().callEvent(new MTProjectileHitEvent(p, tool, e));
     }
 
 	@EventHandler
     public void onBowFire(ProjectileLaunchEvent e) {
-        if (e.isCancelled()) { return; }
-        if (!(e.getEntity().getShooter() instanceof Player)) { return; }
+        if (e.isCancelled()) return;
+        if (!(e.getEntity().getShooter() instanceof Player)) return;
 
         Player p = (Player) e.getEntity().getShooter();
         ItemStack tool = p.getInventory().getItemInMainHand();
 
-        if (!modManager.isToolViable(tool)) { return; }
-        if (!modManager.durabilityCheck(e, p, tool)) { return; }
+        if (!modManager.isToolViable(tool)) return;
+        if (!modManager.durabilityCheck(e, p, tool)) return;
 
 
         modManager.addExp(p, tool, config.getInt("ExpPerArrowShot"));

--- a/src/main/java/de/flo56958/MineTinker/Listeners/ItemListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/ItemListener.java
@@ -82,7 +82,10 @@ public class ItemListener implements Listener {
         Inventory inv = p.getInventory();
 
         for (ItemStack is : inv.getContents()) {
+            if (is == null) continue; // More consistent nullability in NotNull fields
+
             boolean isMineTinker = false;
+
             if (Main.getPlugin().getConfig().getBoolean("ItemBehaviour.ForModItems")) { //Modifieritems
                 ItemStack modifierTester = is.clone();
                 modifierTester.setAmount(1);

--- a/src/main/java/de/flo56958/MineTinker/Listeners/ItemListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/ItemListener.java
@@ -1,11 +1,13 @@
 package de.flo56958.MineTinker.Listeners;
 
+import de.flo56958.MineTinker.Data.Lists;
 import de.flo56958.MineTinker.Main;
 import de.flo56958.MineTinker.Modifiers.ModManager;
 import de.flo56958.MineTinker.Modifiers.Modifier;
 import de.flo56958.MineTinker.Modifiers.Types.ModifierType;
 import de.flo56958.MineTinker.Modifiers.Types.Soulbound;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -13,8 +15,11 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.ItemDespawnEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerItemBreakEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
 
 public class ItemListener implements Listener {
 
@@ -92,6 +97,7 @@ public class ItemListener implements Listener {
                     }
                 }
             }
+
             if (modManager.isArmorViable(is) || modManager.isToolViable(is) || modManager.isWandViable(is)) { isMineTinker = true; }
 
             if (!isMineTinker) { continue; }
@@ -104,5 +110,31 @@ public class ItemListener implements Listener {
 
             is.setAmount(0);
         }
+    }
+
+    @EventHandler
+    public void onItemBreak(PlayerItemBreakEvent e) {
+        Player p = e.getPlayer();
+        ItemStack item = e.getBrokenItem();
+
+        if (Lists.WORLDS.contains(p.getWorld().getName())) { return; }
+        if (!modManager.isToolViable(item)) { return; }
+
+        if (!Main.getPlugin().getConfig().getBoolean("ItemBehaviour.StopBreakEvent")) { return; }
+
+        if (Main.getPlugin().getConfig().getBoolean("ItemBehaviour.AlertPlayerOnBreak")) {
+            e.getPlayer().sendMessage(ChatColor.translateAlternateColorCodes('&',
+                    "&cLooks like your tool broke! Giving it back with 1 durability."
+            ));
+        }
+
+        ItemMeta meta = item.getItemMeta();
+
+        if (meta instanceof Damageable) {
+            ((Damageable) meta).setDamage(1);
+            item.setItemMeta(meta);
+        }
+
+        p.getInventory().addItem(item);
     }
 }

--- a/src/main/java/de/flo56958/MineTinker/Listeners/ItemListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/ItemListener.java
@@ -25,12 +25,11 @@ public class ItemListener implements Listener {
 
     private final ModManager modManager = ModManager.instance();
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onDespawn(ItemDespawnEvent e) {
-        if (e.isCancelled()) return;
-
         Item item = e.getEntity();
         ItemStack is = item.getItemStack();
+
         if (!(modManager.isArmorViable(is) || modManager.isToolViable(is) || modManager.isWandViable(is))) return;
 
         if (Main.getPlugin().getConfig().getBoolean("ItemBehaviour.SetPersistent")) {
@@ -39,10 +38,8 @@ public class ItemListener implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onItemDrop(PlayerDropItemEvent e) {
-        if (e.isCancelled()) return;
-
         Item item = e.getItemDrop();
         ItemStack is = item.getItemStack();
 
@@ -67,9 +64,11 @@ public class ItemListener implements Listener {
             item.setCustomName(is.getItemMeta().getDisplayName());
             item.setCustomNameVisible(true);
         }
+
         if (Main.getPlugin().getConfig().getBoolean("ItemBehaviour.SetGlowing")) {
             item.setGlowing(true);
         }
+
         if (Main.getPlugin().getConfig().getBoolean("ItemBehaviour.SetInvulnerable")) {
             item.setInvulnerable(true);
         }

--- a/src/main/java/de/flo56958/MineTinker/Listeners/ItemListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/ItemListener.java
@@ -27,11 +27,11 @@ public class ItemListener implements Listener {
 
     @EventHandler
     public void onDespawn(ItemDespawnEvent e) {
-        if (e.isCancelled()) { return; }
+        if (e.isCancelled()) return;
 
         Item item = e.getEntity();
         ItemStack is = item.getItemStack();
-        if (!(modManager.isArmorViable(is) || modManager.isToolViable(is) || modManager.isWandViable(is))) { return; }
+        if (!(modManager.isArmorViable(is) || modManager.isToolViable(is) || modManager.isWandViable(is))) return;
 
         if (Main.getPlugin().getConfig().getBoolean("ItemBehaviour.SetPersistent")) {
             e.setCancelled(true);
@@ -41,7 +41,7 @@ public class ItemListener implements Listener {
 
     @EventHandler
     public void onItemDrop(PlayerDropItemEvent e) {
-        if (e.isCancelled()) { return; }
+        if (e.isCancelled()) return;
 
         Item item = e.getItemDrop();
         ItemStack is = item.getItemStack();
@@ -61,9 +61,9 @@ public class ItemListener implements Listener {
         }
         if (modManager.isArmorViable(is) || modManager.isToolViable(is) || modManager.isWandViable(is)) { isMineTinker = true; }
 
-        if (!isMineTinker) { return; }
+        if (!isMineTinker) return;
 
-        if (Main.getPlugin().getConfig().getBoolean("ItemBehaviour.ShowName")) {
+        if (Main.getPlugin().getConfig().getBoolean("ItemBehaviour.ShowName") && is.getItemMeta() != null) {
             item.setCustomName(is.getItemMeta().getDisplayName());
             item.setCustomNameVisible(true);
         }
@@ -77,14 +77,12 @@ public class ItemListener implements Listener {
 
     @EventHandler
     public void onPlayerDeath(PlayerDeathEvent e) {
-        if (e.getKeepInventory()) { return; }
+        if (e.getKeepInventory()) return;
 
         Player p = e.getEntity();
         Inventory inv = p.getInventory();
 
         for (ItemStack is : inv.getContents()) {
-            if (is == null) { continue; }
-
             boolean isMineTinker = false;
             if (Main.getPlugin().getConfig().getBoolean("ItemBehaviour.ForModItems")) { //Modifieritems
                 ItemStack modifierTester = is.clone();
@@ -117,10 +115,10 @@ public class ItemListener implements Listener {
         Player p = e.getPlayer();
         ItemStack item = e.getBrokenItem();
 
-        if (Lists.WORLDS.contains(p.getWorld().getName())) { return; }
-        if (!modManager.isToolViable(item)) { return; }
+        if (Lists.WORLDS.contains(p.getWorld().getName())) return;
+        if (!modManager.isToolViable(item)) return;
 
-        if (!Main.getPlugin().getConfig().getBoolean("ItemBehaviour.StopBreakEvent")) { return; }
+        if (!Main.getPlugin().getConfig().getBoolean("ItemBehaviour.StopBreakEvent")) return;
 
         if (Main.getPlugin().getConfig().getBoolean("ItemBehaviour.AlertPlayerOnBreak")) {
             e.getPlayer().sendMessage(ChatColor.translateAlternateColorCodes('&',

--- a/src/main/java/de/flo56958/MineTinker/Listeners/PlayerListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/PlayerListener.java
@@ -25,9 +25,8 @@ public class PlayerListener implements Listener {
     private static final ModManager modManager = ModManager.instance();
 
     @SuppressWarnings("deprecation")
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
     public void onInventoryClick(InventoryClickEvent e) {
-        if (e.isCancelled()) return;
         if (Lists.WORLDS.contains(e.getWhoClicked().getWorld().getName())) return;
         if (e.getSlot() < 0) return;
         if (!(e.getClickedInventory() instanceof PlayerInventory || e.getClickedInventory() instanceof DoubleChestInventory || e.getClickedInventory() instanceof CraftInventory)) return;
@@ -35,14 +34,14 @@ public class PlayerListener implements Listener {
         ItemStack tool = e.getClickedInventory().getItem(e.getSlot());
 
         if (!(modManager.isToolViable(tool) || modManager.isWandViable(tool) || modManager.isArmorViable(tool))) return;
-
         if (!(Main.getPlugin().getConfig().getBoolean("Repairable") && e.getWhoClicked().hasPermission("minetinker.tool.repair"))) return;
-
         if (tool == null) return;
 
         ItemStack repair = e.getWhoClicked().getItemOnCursor();
         String[] name = tool.getType().toString().split("_");
+
         boolean eligible = false;
+
         if (name[0].toLowerCase().equals("wooden") && Lists.getWoodPlanks().contains(repair.getType())) {
             eligible = true;
         } else if (name[0].toLowerCase().equals("stone") && (repair.getType().equals(Material.COBBLESTONE) || repair.getType().equals(Material.STONE))) {
@@ -68,19 +67,24 @@ public class PlayerListener implements Listener {
         } else if (name[0].toLowerCase().equals("turtle") && repair.getType().equals(Material.SCUTE)) {
             eligible = true;
         }
+
         if (eligible) {
             double dura = tool.getDurability();
             double maxDura = tool.getType().getMaxDurability();
             int amount = e.getWhoClicked().getItemOnCursor().getAmount();
             double percent = Main.getPlugin().getConfig().getDouble("DurabilityPercentageRepair");
+
             while (amount > 0 && dura > 0) {
                 dura = dura - (maxDura * percent);
                 amount--;
             }
+
             if (dura < 0) {
                 dura = 0;
             }
+
             tool.setDurability((short) dura);
+
             e.getWhoClicked().getItemOnCursor().setAmount(amount);
             e.setCancelled(true);
         }
@@ -95,6 +99,7 @@ public class PlayerListener implements Listener {
     public void onJoin(PlayerJoinEvent e) {
         Lists.BLOCKFACE.put(e.getPlayer(), null);
         Power.HASPOWER.put(e.getPlayer(), false);
+
         if (Main.getPlugin().getConfig().getBoolean("SendUpdateNotificationToOPs")) {
             if (e.getPlayer().isOp()) {
                 if (Main.getUpdater() != null) {
@@ -125,6 +130,7 @@ public class PlayerListener implements Listener {
     @EventHandler(priority = EventPriority.LOW)
     public void onInteract(PlayerInteractEvent e) {
         if (Lists.WORLDS.contains(e.getPlayer().getWorld().getName())) return;
+
         if (!e.getBlockFace().equals(BlockFace.SELF)) {
             Lists.BLOCKFACE.replace(e.getPlayer(), e.getBlockFace());
         }

--- a/src/main/java/de/flo56958/MineTinker/Listeners/PlayerListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/PlayerListener.java
@@ -100,8 +100,8 @@ public class PlayerListener implements Listener {
         Lists.BLOCKFACE.put(e.getPlayer(), null);
         Power.HASPOWER.put(e.getPlayer(), false);
 
-        if (Main.getPlugin().getConfig().getBoolean("SendUpdateNotificationToOPs")) {
-            if (e.getPlayer().isOp()) {
+        if (Main.getPlugin().getConfig().getBoolean("CheckForUpdates")) {
+            if (e.getPlayer().hasPermission("minetinker.update.notify")) {
                 if (Main.getUpdater() != null) {
                     if (Main.getUpdater().getHasUpdate()) {
                         ChatWriter.sendMessage(e.getPlayer(), ChatColor.GOLD, "There's is an update available on spigotmc.org!");

--- a/src/main/java/de/flo56958/MineTinker/Listeners/PlayerListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/PlayerListener.java
@@ -27,18 +27,18 @@ public class PlayerListener implements Listener {
     @SuppressWarnings("deprecation")
 	@EventHandler
     public void onInventoryClick(InventoryClickEvent e) {
-        if (e.isCancelled()) { return; }
-        if (Lists.WORLDS.contains(e.getWhoClicked().getWorld().getName())) { return; }
-        if (e.getSlot() < 0) { return; }
-        if (!(e.getClickedInventory() instanceof PlayerInventory || e.getClickedInventory() instanceof DoubleChestInventory || e.getClickedInventory() instanceof CraftInventory)) { return; }
+        if (e.isCancelled()) return;
+        if (Lists.WORLDS.contains(e.getWhoClicked().getWorld().getName())) return;
+        if (e.getSlot() < 0) return;
+        if (!(e.getClickedInventory() instanceof PlayerInventory || e.getClickedInventory() instanceof DoubleChestInventory || e.getClickedInventory() instanceof CraftInventory)) return;
 
         ItemStack tool = e.getClickedInventory().getItem(e.getSlot());
 
-        if (!(modManager.isToolViable(tool) || modManager.isWandViable(tool) || modManager.isArmorViable(tool))) { return; }
+        if (!(modManager.isToolViable(tool) || modManager.isWandViable(tool) || modManager.isArmorViable(tool))) return;
 
-        if (!(Main.getPlugin().getConfig().getBoolean("Repairable") && e.getWhoClicked().hasPermission("minetinker.tool.repair"))) { return; }
+        if (!(Main.getPlugin().getConfig().getBoolean("Repairable") && e.getWhoClicked().hasPermission("minetinker.tool.repair"))) return;
 
-        if (e.getWhoClicked().getItemOnCursor() == null) { return; }
+        if (tool == null) return;
 
         ItemStack repair = e.getWhoClicked().getItemOnCursor();
         String[] name = tool.getType().toString().split("_");
@@ -124,7 +124,7 @@ public class PlayerListener implements Listener {
      */
     @EventHandler(priority = EventPriority.LOW)
     public void onInteract(PlayerInteractEvent e) {
-        if (Lists.WORLDS.contains(e.getPlayer().getWorld().getName())) { return; }
+        if (Lists.WORLDS.contains(e.getPlayer().getWorld().getName())) return;
         if (!e.getBlockFace().equals(BlockFace.SELF)) {
             Lists.BLOCKFACE.replace(e.getPlayer(), e.getBlockFace());
         }

--- a/src/main/java/de/flo56958/MineTinker/Listeners/TinkerListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/TinkerListener.java
@@ -33,10 +33,12 @@ public class TinkerListener implements Listener {
     public void onToolUpgrade(ToolUpgradeEvent e) {
         Player p = e.getPlayer();
         ItemStack tool = e.getTool();
+
         if (e.isSuccessful()) {
             if (config.getBoolean("Sound.OnUpgrade")) {
                 p.playSound(p.getLocation(), Sound.BLOCK_ANVIL_USE, 1.0F, 0.5F);
             }
+
             ChatWriter.sendActionBar(p, ItemGenerator.getDisplayName(tool) + " is now " + tool.getType().toString().split("_")[0] + "!");
             ChatWriter.log(false, p.getDisplayName() + " upgraded " + ItemGenerator.getDisplayName(tool) + ChatColor.WHITE + " (" + tool.getType().toString() + ") to " + tool.getType().toString() + "!");
         } else {
@@ -55,6 +57,7 @@ public class TinkerListener implements Listener {
         if (config.getBoolean("Sound.OnModding")) {
             p.playSound(p.getLocation(), Sound.BLOCK_ANVIL_USE, 1.0F, 0.5F);
         }
+
         ChatWriter.sendActionBar(p, ItemGenerator.getDisplayName(tool) + ChatColor.WHITE + " has now " + mod.getColor() + mod.getName() + ChatColor.WHITE + " and " + e.getSlotsRemaining() + " free Slots remaining!");
         ChatWriter.log(false, p.getDisplayName() + " modded " + ItemGenerator.getDisplayName(tool) +  ChatColor.GRAY + " (" + tool.getType().toString() + ") with " + mod.getColor() + mod.getName() + ChatColor.GRAY + " " + modManager.getModLevel(tool, mod) + "!");
     }
@@ -87,16 +90,17 @@ public class TinkerListener implements Listener {
 
         if (config.getInt("AddModifierSlotsPerLevel") > 0) {
             int slots = modManager.getFreeSlots(tool);
+
             if (!(slots == Integer.MAX_VALUE || slots < 0)) {
                 slots += config.getInt("AddModifierSlotsPerLevel");
             } else {
                 slots = Integer.MAX_VALUE;
             }
+
             modManager.setFreeSlots(tool, slots);
         }
 
         ChatWriter.sendActionBar(p, ItemGenerator.getDisplayName(tool) + ChatColor.GOLD + " just got a Level-Up!");
-
         ChatWriter.log(false, p.getDisplayName() + " leveled up " + ItemGenerator.getDisplayName(tool) + ChatColor.WHITE + " (" + tool.getType().toString() + ")!");
 
         //------------------------------------------------------------------------------------------------------------------------
@@ -105,18 +109,23 @@ public class TinkerListener implements Listener {
             Random rand = new Random();
             if (config.getBoolean("LevelUpEvents.DurabilityRepair.enabled")) {
                 int n = rand.nextInt(100);
+
                 if (n <= config.getInt("LevelUpEvents.DurabilityRepair.percentage")) {
                     tool.setDurability((short) -1);
                 }
             }
             if (config.getBoolean("LevelUpEvents.DropLoot.enabled")) {
                 int n = rand.nextInt(100);
+
                 if (n <= config.getInt("LevelUpEvents.DropLoot.percentage")) {
                     int index = rand.nextInt(Lists.DROPLOOT.size());
                     Material m = Material.getMaterial(Lists.DROPLOOT.get(index));
+
                     int amount = rand.nextInt(config.getInt("LevelUpEvents.DropLoot.maximumDrop") - config.getInt("LevelUpEvents.DropLoot.minimumDrop"));
                     amount = amount + config.getInt("LevelUpEvents.DropLoot.minimumDrop");
+
                     ItemStack drop = new ItemStack(m, amount);
+
                     if (p.getInventory().addItem(drop).size() != 0) { //adds items to (full) inventory
                         p.getWorld().dropItem(p.getLocation(), drop); //drops item when inventory is full
                     } // no else as it gets added in if
@@ -129,13 +138,17 @@ public class TinkerListener implements Listener {
                         if (p.getInventory().getItem(i) != null && p.getInventory().getItem(i).equals(tool)) {  //Can be NULL!
                             ItemStack newTool = null;
                             ItemStack safety = tool.clone();
+
                             List<Modifier> mods = new ArrayList<>(modManager.getAllowedMods()); //necessary as the failed modifiers get removed from the list (so a copy is in order)
+
                             while (newTool == null) {
                                 int index = new Random().nextInt(mods.size());
                                 newTool = mods.get(index).applyMod(p, safety, true);
+
                                 if (newTool == null) {
                                     mods.remove(index); //Remove the failed modifier from the the list of the possibles
                                 }
+
                                 if (mods.isEmpty()) { break; } //Secures that the while will terminate after some time (if all modifiers were removed)
                             }
                             if (newTool != null) { //while could have been broken out of -> newTool could still be null

--- a/src/main/java/de/flo56958/MineTinker/Listeners/TinkerListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/TinkerListener.java
@@ -117,7 +117,7 @@ public class TinkerListener implements Listener {
                     int amount = rand.nextInt(config.getInt("LevelUpEvents.DropLoot.maximumDrop") - config.getInt("LevelUpEvents.DropLoot.minimumDrop"));
                     amount = amount + config.getInt("LevelUpEvents.DropLoot.minimumDrop");
                     ItemStack drop = new ItemStack(m, amount);
-                    if(p.getInventory().addItem(drop).size() != 0) { //adds items to (full) inventory
+                    if (p.getInventory().addItem(drop).size() != 0) { //adds items to (full) inventory
                         p.getWorld().dropItem(p.getLocation(), drop); //drops item when inventory is full
                     } // no else as it gets added in if
                 }

--- a/src/main/java/de/flo56958/MineTinker/Listeners/TridentListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/TridentListener.java
@@ -14,14 +14,14 @@ public class TridentListener implements Listener {
 
     public static final HashMap<Trident, ItemStack> TridentToItemStack = new HashMap<>();
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onTridentLaunch(ProjectileLaunchEvent e) {
-        if (e.isCancelled()) return;
         if (!(e.getEntity().getShooter() instanceof Player)) return;
         if (!(e.getEntity() instanceof Trident)) return;
 
         Player p = (Player) e.getEntity().getShooter();
         ItemStack trident = p.getInventory().getItemInMainHand().clone();
+
         if (!ModManager.instance().isToolViable(trident)) return;
 
         ModManager.instance().addExp(p, trident, -20000);

--- a/src/main/java/de/flo56958/MineTinker/Listeners/TridentListener.java
+++ b/src/main/java/de/flo56958/MineTinker/Listeners/TridentListener.java
@@ -16,13 +16,13 @@ public class TridentListener implements Listener {
 
     @EventHandler
     public void onTridentLaunch(ProjectileLaunchEvent e) {
-        if (e.isCancelled()) { return; }
-        if (!(e.getEntity().getShooter() instanceof Player)) { return; }
-        if (!(e.getEntity() instanceof Trident)) { return; }
+        if (e.isCancelled()) return;
+        if (!(e.getEntity().getShooter() instanceof Player)) return;
+        if (!(e.getEntity() instanceof Trident)) return;
 
         Player p = (Player) e.getEntity().getShooter();
         ItemStack trident = p.getInventory().getItemInMainHand().clone();
-        if (!ModManager.instance().isToolViable(trident)) { return; }
+        if (!ModManager.instance().isToolViable(trident)) return;
 
         ModManager.instance().addExp(p, trident, -20000);
         TridentToItemStack.put((Trident) e.getEntity(), trident);

--- a/src/main/java/de/flo56958/MineTinker/Main.java
+++ b/src/main/java/de/flo56958/MineTinker/Main.java
@@ -28,9 +28,11 @@ public class Main extends JavaPlugin {
         loadConfig();
 
         ModManager.instance();
+
         Commands cmd = new Commands();
         this.getCommand("minetinker").setExecutor(cmd); // must be after internals as it would throw a NullPointerException
         this.getCommand("minetinker").setTabCompleter(cmd);
+
         ChatWriter.log(false, "Registered commands!");
 
         if (getConfig().getBoolean("AllowCrafting")) {
@@ -38,6 +40,7 @@ public class Main extends JavaPlugin {
             convertListener.register();
             Bukkit.getPluginManager().registerEvents(convertListener, this);
         }
+
         Bukkit.getPluginManager().registerEvents(new BlockListener(), this);
         Bukkit.getPluginManager().registerEvents(new AnvilListener(), this);
         Bukkit.getPluginManager().registerEvents(new ArmorListener(), this);
@@ -53,20 +56,24 @@ public class Main extends JavaPlugin {
         if (!getConfig().getBoolean("AllowEnchanting")) {
             Bukkit.getPluginManager().registerEvents(new EnchantingTableListener(), this);
         }
+
         if (ConfigurationManager.getConfig("Elevator.yml").getBoolean("Elevator.enabled")) {
             Bukkit.getPluginManager().registerEvents(new ElevatorListener(), this);
             CraftingRecipes.registerElevatorMotor();
             ChatWriter.log(false, "Enabled Elevators!");
         }
+
         if (ConfigurationManager.getConfig("BuildersWand.yml").getBoolean("BuildersWand.enabled")) {
             Bukkit.getPluginManager().registerEvents(new BuildersWandListener(), this);
             BuildersWandListener.reload();
             ChatWriter.log(false, "Enabled BuildersWands!");
         }
+
         if (getConfig().getBoolean("EasyHarvest.enabled")) {
             Bukkit.getPluginManager().registerEvents(new EasyHarvestListener(), this);
             ChatWriter.log(false, "Enabled EasyHarvest!");
         }
+
         ChatWriter.log(false, "Registered events!");
 
         if (getConfig().getBoolean("logging.metrics")) {
@@ -98,6 +105,7 @@ public class Main extends JavaPlugin {
     private void loadConfig() {
         getConfig().options().copyDefaults(true);
         saveConfig();
+
         ChatWriter.log(false, "Config loaded!");
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Main.java
+++ b/src/main/java/de/flo56958/MineTinker/Main.java
@@ -14,7 +14,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitRunnable;
 
 public class Main extends JavaPlugin {
 

--- a/src/main/java/de/flo56958/MineTinker/Main.java
+++ b/src/main/java/de/flo56958/MineTinker/Main.java
@@ -83,12 +83,9 @@ public class Main extends JavaPlugin {
         }
 
         if (getConfig().getBoolean("CheckForUpdates")) {
-            new BukkitRunnable() {
-                @Override
-                public void run() {
-                    updater.checkForUpdate();
-                }
-            }.runTaskLater(Main.getPlugin(), 20);
+            Bukkit.getScheduler().scheduleAsyncDelayedTask(this, () -> {
+                updater.checkForUpdate();
+            }, 20);
         }
     }
 

--- a/src/main/java/de/flo56958/MineTinker/MineTinkerAPI.java
+++ b/src/main/java/de/flo56958/MineTinker/MineTinkerAPI.java
@@ -45,6 +45,7 @@ public class MineTinkerAPI {
         if (api == null) {
             api = new MineTinkerAPI();
         }
+
         return api;
     }
 
@@ -66,6 +67,7 @@ public class MineTinkerAPI {
      */
     public FileConfiguration getConfig(String folder, String name) {
         ConfigurationManager.loadConfig(folder, name);
+
         return ConfigurationManager.getConfig(name);
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Craftable.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Craftable.java
@@ -24,6 +24,7 @@ public interface Craftable {
 
                 // TODO: Make this safer
                 newRecipe.shape(top, middle, bottom); //makes recipe
+
                 for (String key : materials.getKeys(false)) {
                     newRecipe.setIngredient(key.charAt(0), Material.getMaterial(materials.getString(key)));
                 }

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Craftable.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Craftable.java
@@ -21,10 +21,13 @@ public interface Craftable {
                 String middle = config.getString(name + ".Recipe.Middle");
                 String bottom = config.getString(name + ".Recipe.Bottom");
                 ConfigurationSection materials = config.getConfigurationSection(name + ".Recipe.Materials");
+
+                // TODO: Make this safer
                 newRecipe.shape(top, middle, bottom); //makes recipe
                 for (String key : materials.getKeys(false)) {
                     newRecipe.setIngredient(key.charAt(0), Material.getMaterial(materials.getString(key)));
                 }
+
                 Main.getPlugin().getServer().addRecipe(newRecipe); //adds recipe
                 ChatWriter.log(false, "Registered recipe for the " + name + "-Modifier!");
                 ModManager.instance().recipe_Namespaces.add(nkey);

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Enchantable.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Enchantable.java
@@ -14,8 +14,8 @@ public interface Enchantable {
     void enchantItem(Player p, ItemStack item);
 
     default void _createModifierItem(FileConfiguration config, Player p, Modifier mod, String modifier) {
-        if (config.getBoolean(modifier + ".Recipe.Enabled")) { return; }
-        if (p.getGameMode().equals(GameMode.CREATIVE)) {
+        if (config.getBoolean(modifier + ".Recipe.Enabled")) return;
+        if (p.getGameMode().equals(GameMode.CREATIVE) && p.getLocation().getWorld() != null) {
             p.getLocation().getWorld().dropItemNaturally(p.getLocation(), mod.getModItem());
             if (Main.getPlugin().getConfig().getBoolean("Sound.OnEnchanting")) {
                 p.playSound(p.getLocation(), Sound.BLOCK_ENCHANTMENT_TABLE_USE, 1.0F, 0.5F);

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Enchantable.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Enchantable.java
@@ -15,23 +15,30 @@ public interface Enchantable {
 
     default void _createModifierItem(FileConfiguration config, Player p, Modifier mod, String modifier) {
         if (config.getBoolean(modifier + ".Recipe.Enabled")) return;
+
         if (p.getGameMode().equals(GameMode.CREATIVE) && p.getLocation().getWorld() != null) {
             p.getLocation().getWorld().dropItemNaturally(p.getLocation(), mod.getModItem());
+
             if (Main.getPlugin().getConfig().getBoolean("Sound.OnEnchanting")) {
                 p.playSound(p.getLocation(), Sound.BLOCK_ENCHANTMENT_TABLE_USE, 1.0F, 0.5F);
             }
+
             ChatWriter.log(false, p.getDisplayName() + " created a " + mod.getName() + "-Modifiers in Creative!");
         } else if (p.getLevel() >= config.getInt(modifier + ".EnchantCost")) {
             int amount = p.getInventory().getItemInMainHand().getAmount();
             int newLevel = p.getLevel() - config.getInt(modifier + ".EnchantCost");
+
             p.setLevel(newLevel);
             p.getInventory().getItemInMainHand().setAmount(amount - 1);
+
             if (p.getInventory().addItem(mod.getModItem()).size() != 0) { //adds items to (full) inventory
                 p.getWorld().dropItem(p.getLocation(), mod.getModItem());
             } // no else as it gets added in if
+
             if (Main.getPlugin().getConfig().getBoolean("Sound.OnEnchanting")) {
                 p.playSound(p.getLocation(), Sound.BLOCK_ENCHANTMENT_TABLE_USE, 1.0F, 0.5F);
             }
+
             ChatWriter.log(false, p.getDisplayName() + " created a " + mod.getName() + "-Modifiers!");
         } else {
             ChatWriter.sendActionBar(p, ChatColor.RED + "" + config.getInt(modifier + ".EnchantCost") + " levels required!");

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/ModManager.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/ModManager.java
@@ -13,6 +13,7 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.Sound;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.craftbukkit.v1_14_R1.inventory.CraftItemStack;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.inventory.ItemFlag;
@@ -37,11 +38,11 @@ public class ModManager {
 
         layout = ConfigurationManager.getConfig("layout.yml");
         layout.options().copyDefaults(true);
-
         layout.addDefault("UseRomans.Level", true);
         layout.addDefault("UseRomans.Exp", false);
         layout.addDefault("UseRomans.FreeSlots", false);
         layout.addDefault("UseRomans.ModifierLevels", true);
+
         ArrayList<String> loreLayout = new ArrayList<>();
         loreLayout.add("%GOLD%Level %WHITE%%LEVEL%");
         loreLayout.add("%GOLD%Exp: %WHITE%%EXP% / %NEXT_LEVEL_EXP%");
@@ -75,6 +76,8 @@ public class ModManager {
 
     private List<String> loreScheme;
     private String modifierLayout;
+
+    private boolean allowBookConvert = config.getBoolean("ConvertBookToModifier");
 
     /**
      * Class constructor (no parameters)
@@ -212,6 +215,12 @@ public class ModManager {
          mes = mes.replaceAll("%PLUGIN%", Main.getPlugin().getName());
          ChatWriter.logColor(mes);
     }
+
+    /**
+     * should we let the player convert enchanted books to modifier items
+     * @return
+     */
+    public boolean allowBookToModifier() { return this.allowBookConvert; }
 
     /**
      * get all the modifiers in the list
@@ -626,6 +635,20 @@ public class ModManager {
             if (m.getType().getNBTKey() != null && m.getType().getNBTKey().equals(name)) {
                 return m;
             }
+        }
+
+        return null;
+    }
+
+    /**
+     * Gets the first found modifier that applies the supplied enchantment.
+     *
+     * @param enchantment
+     * @return
+     */
+    public Modifier getModifierFromEnchantment(Enchantment enchantment) {
+        for (Modifier modifier : getAllMods()) {
+            if (modifier.getAppliedEnchantments().contains(enchantment)) return modifier;
         }
 
         return null;

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/ModManager.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/ModManager.java
@@ -124,6 +124,7 @@ public class ModManager {
             if (m instanceof Craftable) {
                 this.craftableMods.add(m);
             }
+
             if (m instanceof Enchantable) {
                 this.enchantableMods.add(m);
             }
@@ -189,6 +190,7 @@ public class ModManager {
     public void register(Modifier mod) {
     	if (!mods.contains(mod)) {
 	        mods.add(mod);
+
 	        String mes = "%GREEN%Registered the %MOD% %GREEN%modifier from %PLUGIN%.";
 	        mes = ChatWriter.addColors(mes);
 	        mes = mes.replaceAll("%MOD%", mod.getColor() + mod.getName());
@@ -203,6 +205,7 @@ public class ModManager {
      */
     public void unregister(Modifier mod) {
     	 mods.remove(mod);
+
          String mes = "%GREEN%Unregistered the %MOD% %GREEN%modifier from %PLUGIN%.";
          mes = ChatWriter.addColors(mes);
          mes = mes.replaceAll("%MOD%", mod.getColor() + mod.getName());
@@ -247,6 +250,7 @@ public class ModManager {
                 return m;
             }
         }
+
         return null;
     }
 
@@ -262,6 +266,7 @@ public class ModManager {
                 return m;
             }
         }
+
         return null;
     }
 
@@ -546,6 +551,7 @@ public class ModManager {
      */
     public void convertItemStack(ItemStack is) {
         Material m = is.getType();
+
         if ((ToolType.AXE.getMaterials().contains(m)
                 || ToolType.BOW.getMaterials().contains(m)
                 || ToolType.HOE.getMaterials().contains(m)
@@ -563,6 +569,7 @@ public class ModManager {
                 || ToolType.ELYTRA.getMaterials().contains(m)) {
             setNBTTag(is, "IdentifierArmor", new NBTTagInt(0));
         } else return;
+
         setExp(is, 0);
         setLevel(is, 1);
         setFreeSlots(is, config.getInt("StartingModifierSlots"));
@@ -612,12 +619,15 @@ public class ModManager {
         if (item.getType().equals(get(ModifierType.EXTRA_MODIFIER).getModItem().getType())
                 && !hasNBTTag(item, "modifierItem")) { return get(ModifierType.EXTRA_MODIFIER); }
         if (!hasNBTTag(item, "modifierItem")) { return null; }
+
         String name = Objects.requireNonNull(getNBTTag(item, "modifierItem")).asString();
+
         for (Modifier m : mods) {
             if (m.getType().getNBTKey() != null && m.getType().getNBTKey().equals(name)) {
                 return m;
             }
         }
+
         return null;
     }
 
@@ -635,9 +645,11 @@ public class ModManager {
         if (meta != null) {
             if (tool.getType().getMaxDurability() - ((Damageable) meta).getDamage() <= 2 && config.getBoolean("UnbreakableTools")) {
                 e.setCancelled(true);
+
                 if (config.getBoolean("Sound.OnBreaking")) {
                     p.playSound(p.getLocation(), Sound.ENTITY_ITEM_BREAK, 0.5F, 0.5F);
                 }
+
                 return false;
             }
         }

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Modifier.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Modifier.java
@@ -113,14 +113,17 @@ public abstract class Modifier {
             pluginManager.callEvent(new ModifierFailEvent(p, tool, mod, ModifierFailCause.NO_FREE_SLOTS, isCommand));
             return null;
         }
+
         if (!p.hasPermission("minetinker.modifiers." + permission + ".apply")) {
             pluginManager.callEvent(new ModifierFailEvent(p, tool, mod, ModifierFailCause.NO_PERMISSION, isCommand));
             return null;
         }
+
         if (!mod.getAllowedTools().contains(ToolType.get(tool.getType()))) {
             pluginManager.callEvent(new ModifierFailEvent(p, tool, mod, ModifierFailCause.INVALID_TOOLTYPE, isCommand));
             return null;
         }
+
         if (modManager.getModLevel(tool, mod) >= mod.getMaxLvl()) {
             pluginManager.callEvent(new ModifierFailEvent(p, tool, mod, ModifierFailCause.MOD_MAXLEVEL, isCommand));
             return null;

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Modifier.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Modifier.java
@@ -9,12 +9,14 @@ import de.flo56958.MineTinker.Utilities.ChatWriter;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public abstract class Modifier {
     //TODO: Add option to change Modifier-Item
@@ -107,6 +109,11 @@ public abstract class Modifier {
      * @return is the modifier allowed
      */
     public abstract boolean isAllowed();
+
+    /**
+     * @return a list of enchantments that may be applied when the modifier is applied
+     */
+    public abstract List<Enchantment> getAppliedEnchantments();
 
     public static ItemStack checkAndAdd(Player p, ItemStack tool, Modifier mod, String permission, boolean isCommand) {
         if ((modManager.getFreeSlots(tool) < 1 && !mod.getType().equals(ModifierType.EXTRA_MODIFIER)) && !isCommand) {

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Aquaphilic.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Aquaphilic.java
@@ -19,6 +19,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class Aquaphilic extends Modifier implements Craftable {
 
@@ -33,6 +34,16 @@ public class Aquaphilic extends Modifier implements Craftable {
         super(ModifierType.AQUAPHILIC,
                 new ArrayList<>(Arrays.asList(ToolType.BOOTS, ToolType.HELMET)),
                 Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+        enchantments.add(Enchantment.DEPTH_STRIDER);
+        enchantments.add(Enchantment.OXYGEN);
+        enchantments.add(Enchantment.WATER_WORKER);
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Aquaphilic.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Aquaphilic.java
@@ -82,17 +82,20 @@ public class Aquaphilic extends Modifier implements Craftable {
 
         ItemMeta meta = tool.getItemMeta();
 
-        if (ToolType.BOOTS.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.DEPTH_STRIDER, modManager.getModLevel(tool, this), true);
-        } else if (ToolType.HELMET.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.OXYGEN, modManager.getModLevel(tool, this), true);
-            meta.addEnchant(Enchantment.WATER_WORKER, modManager.getModLevel(tool, this), true);
-        }
+        if (meta != null ) {
+            if (ToolType.BOOTS.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.DEPTH_STRIDER, modManager.getModLevel(tool, this), true);
+            } else if (ToolType.HELMET.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.OXYGEN, modManager.getModLevel(tool, this), true);
+                meta.addEnchant(Enchantment.WATER_WORKER, modManager.getModLevel(tool, this), true);
+            }
 
-        if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
-            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-        } else {
-            meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+            if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            } else {
+                meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+            }
+
         }
 
         tool.setItemMeta(meta);
@@ -103,10 +106,14 @@ public class Aquaphilic extends Modifier implements Craftable {
     @Override
     public void removeMod(ItemStack tool) {
         ItemMeta meta = tool.getItemMeta();
-        meta.removeEnchant(Enchantment.DEPTH_STRIDER);
-        meta.removeEnchant(Enchantment.OXYGEN);
-        meta.removeEnchant(Enchantment.WATER_WORKER);
-        tool.setItemMeta(meta);
+
+        if (meta != null) {
+            meta.removeEnchant(Enchantment.DEPTH_STRIDER);
+            meta.removeEnchant(Enchantment.OXYGEN);
+            meta.removeEnchant(Enchantment.WATER_WORKER);
+
+            tool.setItemMeta(meta);
+        }
     }
 
     private static FileConfiguration getConfig() {

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/AutoSmelt.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/AutoSmelt.java
@@ -14,6 +14,7 @@ import de.flo56958.MineTinker.Utilities.Modifiers_Config;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -22,6 +23,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 public class AutoSmelt extends Modifier implements Craftable, Listener {
@@ -46,6 +48,13 @@ public class AutoSmelt extends Modifier implements Craftable, Listener {
                 new ArrayList<>(Arrays.asList(ToolType.AXE, ToolType.PICKAXE, ToolType.SHOVEL, ToolType.SHEARS)),
                 Main.getPlugin());
         Bukkit.getPluginManager().registerEvents(this, Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/AutoSmelt.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/AutoSmelt.java
@@ -31,6 +31,7 @@ public class AutoSmelt extends Modifier implements Craftable, Listener {
     private boolean hasParticles;
     private boolean worksUnderWater;
     private boolean smeltStone;
+    private boolean smeltTerracotta;
     private boolean burnCoal;
 
     private static AutoSmelt instance;
@@ -65,6 +66,7 @@ public class AutoSmelt extends Modifier implements Craftable, Listener {
     	config.addDefault(key + ".Sound", true); //Auto-Smelt makes a sound
     	config.addDefault(key + ".Particles", true); //Auto-Smelt will create a particle effect when triggered
     	config.addDefault(key + ".smelt_stone", false);
+    	config.addDefault(key + ".smelt_terracotta", false);
     	config.addDefault(key + ".burn_coal", true);
     	config.addDefault(key + ".works_under_water", true);
     	config.addDefault(key + ".Recipe.Enabled", true);
@@ -88,6 +90,7 @@ public class AutoSmelt extends Modifier implements Craftable, Listener {
         this.worksUnderWater = config.getBoolean(key + ".works_under_water");
         this.smeltStone = config.getBoolean(key + ".smelt_stone");
         this.burnCoal = config.getBoolean(key + ".burn_coal");
+        this.smeltTerracotta = config.getBoolean(key + ".smelt_terracotta");
     }
     
     @Override
@@ -112,6 +115,7 @@ public class AutoSmelt extends Modifier implements Craftable, Listener {
     @EventHandler
     public void effect(MTBlockBreakEvent event) {
         if (event.isCancelled() || !this.isAllowed()) return;
+
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
         Block b = event.getBlock();
@@ -119,7 +123,7 @@ public class AutoSmelt extends Modifier implements Craftable, Listener {
 
     	//FileConfiguration config = getConfig();
     	
-        if (!p.hasPermission("minetinker.modifiers.autosmelt.use")) return;//TODO: Think about more blocks for Auto-Smelt
+        if (!p.hasPermission("minetinker.modifiers.autosmelt.use")) return; //TODO: Think about more blocks for Auto-Smelt
         if (!modManager.hasMod(tool, this)) return;
 
         if (!worksUnderWater) {
@@ -128,7 +132,9 @@ public class AutoSmelt extends Modifier implements Craftable, Listener {
 
         boolean allowLuck = false;
         int amount = 1;
+
         Material loot;
+
         //TODO: CHANGE TO CHECK CONFIG FOR WHAT OUTPUT A BLOCK HAS INSTEAD OF SWITCH CASE
         switch (b.getType()) {
             case STONE:
@@ -148,6 +154,71 @@ public class AutoSmelt extends Modifier implements Craftable, Listener {
 
             case RED_SAND:
                 loot = Material.RED_STAINED_GLASS;
+                break;
+
+            case WHITE_TERRACOTTA:
+                if (!smeltTerracotta) return;
+                loot = Material.WHITE_GLAZED_TERRACOTTA;
+                break;
+            case ORANGE_TERRACOTTA:
+                if (!smeltTerracotta) return;
+                loot = Material.ORANGE_GLAZED_TERRACOTTA;
+                break;
+            case MAGENTA_TERRACOTTA:
+                if (!smeltTerracotta) return;
+                loot = Material.MAGENTA_GLAZED_TERRACOTTA;
+                break;
+            case LIGHT_BLUE_TERRACOTTA:
+                if (!smeltTerracotta) return;
+                loot = Material.LIGHT_BLUE_GLAZED_TERRACOTTA;
+                break;
+            case YELLOW_TERRACOTTA:
+                if (!smeltTerracotta) return;
+                loot = Material.YELLOW_GLAZED_TERRACOTTA;
+                break;
+            case LIME_TERRACOTTA:
+                if (!smeltTerracotta) return;
+                loot = Material.LIME_GLAZED_TERRACOTTA;
+                break;
+            case PINK_TERRACOTTA:
+                if (!smeltTerracotta) return;
+                loot = Material.PINK_GLAZED_TERRACOTTA;
+                break;
+            case GRAY_TERRACOTTA:
+                if (!smeltTerracotta) return;
+                loot = Material.GRAY_GLAZED_TERRACOTTA;
+                break;
+            case LIGHT_GRAY_TERRACOTTA:
+                if (!smeltTerracotta) return;
+                loot = Material.LIGHT_GRAY_GLAZED_TERRACOTTA;
+                break;
+            case CYAN_TERRACOTTA:
+                if (!smeltTerracotta) return;
+                loot = Material.CYAN_GLAZED_TERRACOTTA;
+                break;
+            case PURPLE_TERRACOTTA:
+                if (!smeltTerracotta) return;
+                loot = Material.PURPLE_GLAZED_TERRACOTTA;
+                break;
+            case BLUE_TERRACOTTA:
+                if (!smeltTerracotta) return;
+                loot = Material.BLUE_GLAZED_TERRACOTTA;
+                break;
+            case BROWN_TERRACOTTA:
+                if (!smeltTerracotta) return;
+                loot = Material.BROWN_GLAZED_TERRACOTTA;
+                break;
+            case GREEN_TERRACOTTA:
+                if (!smeltTerracotta) return;
+                loot = Material.GREEN_GLAZED_TERRACOTTA;
+                break;
+            case RED_TERRACOTTA:
+                if (!smeltTerracotta) return;
+                loot = Material.RED_GLAZED_TERRACOTTA;
+                break;
+            case BLACK_TERRACOTTA:
+                if (!smeltTerracotta) return;
+                loot = Material.BLACK_GLAZED_TERRACOTTA;
                 break;
 
             case ACACIA_LOG:

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/AutoSmelt.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/AutoSmelt.java
@@ -111,19 +111,19 @@ public class AutoSmelt extends Modifier implements Craftable, Listener {
      */
     @EventHandler
     public void effect(MTBlockBreakEvent event) {
-        if (event.isCancelled() || !this.isAllowed()) { return; }
+        if (event.isCancelled() || !this.isAllowed()) return;
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
         Block b = event.getBlock();
         BlockBreakEvent e = event.getEvent();
 
-    	FileConfiguration config = getConfig();
+    	//FileConfiguration config = getConfig();
     	
-        if (!p.hasPermission("minetinker.modifiers.autosmelt.use")) { return; }//TODO: Think about more blocks for Auto-Smelt
-        if (!modManager.hasMod(tool, this)) { return; }
+        if (!p.hasPermission("minetinker.modifiers.autosmelt.use")) return;//TODO: Think about more blocks for Auto-Smelt
+        if (!modManager.hasMod(tool, this)) return;
 
         if (!worksUnderWater) {
-            if (p.isSwimming() || p.getWorld().getBlockAt(p.getLocation()).getType().equals(Material.WATER)) { return; }
+            if (p.isSwimming() || p.getWorld().getBlockAt(p.getLocation()).getType().equals(Material.WATER)) return;
         }
 
         boolean allowLuck = false;
@@ -132,7 +132,7 @@ public class AutoSmelt extends Modifier implements Craftable, Listener {
         //TODO: CHANGE TO CHECK CONFIG FOR WHAT OUTPUT A BLOCK HAS INSTEAD OF SWITCH CASE
         switch (b.getType()) {
             case STONE:
-                if (!smeltStone) { return; }
+                if (!smeltStone) return;
             case COBBLESTONE:
                 loot = Material.STONE;
                 break;
@@ -215,7 +215,7 @@ public class AutoSmelt extends Modifier implements Craftable, Listener {
 
             case COAL_ORE:
             case COAL_BLOCK:
-                if (!burnCoal) { return; }
+                if (!burnCoal) return;
                 loot = Material.AIR;
                 break;
 
@@ -230,7 +230,7 @@ public class AutoSmelt extends Modifier implements Craftable, Listener {
 
         Random rand = new Random();
         int n = rand.nextInt(100);
-        if (n <= this.percentagePerLevel * modManager.getModLevel(tool, this)) {
+        if (n <= this.percentagePerLevel * modManager.getModLevel(tool, this) && b.getLocation().getWorld() != null) {
             if (allowLuck && modManager.get(ModifierType.LUCK) != null) {
                 int level = modManager.getModLevel(tool, modManager.get(ModifierType.LUCK));
                 if (level > 0) {

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Beheading.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Beheading.java
@@ -88,7 +88,7 @@ public class Beheading extends Modifier implements Enchantable, Craftable, Liste
      */
     @EventHandler(priority = EventPriority.LOW) //For Directing
     public void effect(MTEntityDeathEvent event) {
-        if (!this.isAllowed()) { return; }
+        if (!this.isAllowed()) return;
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
         LivingEntity mob = event.getEvent().getEntity();
@@ -110,9 +110,13 @@ public class Beheading extends Modifier implements Enchantable, Craftable, Liste
                         loot = new ItemStack(Material.ZOMBIE_HEAD, 1);
                     } else if (mob.getType().equals(EntityType.PLAYER)) {
                         ItemStack head = new ItemStack(Material.PLAYER_HEAD, 1);
-                        SkullMeta headMeta = (SkullMeta) head.getItemMeta();
-                        headMeta.setOwningPlayer((OfflinePlayer) mob);
-                        head.setItemMeta(headMeta);
+
+                        if (head.getItemMeta() != null) {
+                            SkullMeta headMeta = (SkullMeta) head.getItemMeta();
+                            headMeta.setOwningPlayer((OfflinePlayer) mob);
+                            head.setItemMeta(headMeta);
+                        }
+
                         loot = head;
                     }
                     if (loot.getType() != Material.AIR) {
@@ -126,7 +130,7 @@ public class Beheading extends Modifier implements Enchantable, Craftable, Liste
 
     @Override
     public void enchantItem(Player p, ItemStack item) {
-        if (!p.hasPermission("minetinker.modifiers.beheading.craft")) { return; }
+        if (!p.hasPermission("minetinker.modifiers.beheading.craft")) return;
         _createModifierItem(getConfig(), p, this, "Beheading");
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Beheading.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Beheading.java
@@ -15,6 +15,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -26,6 +27,7 @@ import org.bukkit.inventory.meta.SkullMeta;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 public class Beheading extends Modifier implements Enchantable, Craftable, Listener {
@@ -44,6 +46,13 @@ public class Beheading extends Modifier implements Enchantable, Craftable, Liste
                 new ArrayList<>(Arrays.asList(ToolType.AXE, ToolType.BOW, ToolType.SWORD, ToolType.TRIDENT)),
                 Main.getPlugin());
         Bukkit.getPluginManager().registerEvents(this, Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Beheading.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Beheading.java
@@ -89,14 +89,17 @@ public class Beheading extends Modifier implements Enchantable, Craftable, Liste
     @EventHandler(priority = EventPriority.LOW) //For Directing
     public void effect(MTEntityDeathEvent event) {
         if (!this.isAllowed()) return;
+
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
         LivingEntity mob = event.getEvent().getEntity();
         ItemStack loot = new ItemStack(Material.AIR, 1);
+
         if (p.hasPermission("minetinker.modifiers.beheading.use")) {
             if (modManager.hasMod(tool, this)) {
                 Random rand = new Random();
                 int n = rand.nextInt(100);
+
                 if (n <= this.percentagePerLevel * modManager.getModLevel(tool, this)) {
                     if (mob.getType().equals(EntityType.CREEPER)) {
                         loot = new ItemStack(Material.CREEPER_HEAD, 1);
@@ -119,6 +122,7 @@ public class Beheading extends Modifier implements Enchantable, Craftable, Liste
 
                         loot = head;
                     }
+
                     if (loot.getType() != Material.AIR) {
                         event.getEvent().getDrops().add(loot);
                         ChatWriter.log(false, p.getDisplayName() + " triggered Beheading on " + ItemGenerator.getDisplayName(tool) + ChatColor.WHITE + " (" + tool.getType().toString() + ")!");

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Directing.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Directing.java
@@ -67,6 +67,7 @@ public class Directing extends Modifier implements Craftable, Listener {
                 ChatWriter.getColor(config.getString(key + ".Color")),
                 1,
                 modManager.createModifierItem(Material.getMaterial(config.getString(key + ".modifier_item")), ChatWriter.getColor(config.getString(key + ".Color")) + config.getString(key + ".name_modifier"), ChatWriter.addColors(config.getString(key + ".description_modifier")), this));
+
         this.workInPVP = config.getBoolean(key + ".workinpvp");
     }
 
@@ -85,15 +86,18 @@ public class Directing extends Modifier implements Craftable, Listener {
 
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
+
         if (!p.hasPermission("minetinker.modifiers.directing.use")) return;
         if (!modManager.hasMod(tool, this)) return;
 
         List<ItemStack> drops = event.getEvent().getDrops();
+
         for (ItemStack current : drops) {
             if (p.getInventory().addItem(current).size() != 0) { //adds items to (full) inventory
                 p.getWorld().dropItem(p.getLocation(), current);
             } // no else as it gets added in if-clause
         }
+
         drops.clear();
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Directing.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Directing.java
@@ -11,6 +11,7 @@ import de.flo56958.MineTinker.Utilities.Modifiers_Config;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -36,6 +37,13 @@ public class Directing extends Modifier implements Craftable, Listener {
                 new ArrayList<>(Arrays.asList(ToolType.AXE, ToolType.BOW, ToolType.SWORD, ToolType.TRIDENT)),
                 Main.getPlugin());
         Bukkit.getPluginManager().registerEvents(this, Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Ender.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Ender.java
@@ -14,6 +14,7 @@ import de.flo56958.MineTinker.Utilities.ItemGenerator;
 import de.flo56958.MineTinker.Utilities.Modifiers_Config;
 import org.bukkit.*;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.AreaEffectCloud;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -24,6 +25,7 @@ import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class Ender extends Modifier implements Craftable, Listener {
 
@@ -43,6 +45,13 @@ public class Ender extends Modifier implements Craftable, Listener {
                 new ArrayList<>(Arrays.asList(ToolType.BOW, ToolType.TRIDENT)),
                 Main.getPlugin());
         Bukkit.getPluginManager().registerEvents(this, Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Ender.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Ender.java
@@ -92,6 +92,7 @@ public class Ender extends Modifier implements Craftable, Listener {
                 }
             }
         }
+
         return Modifier.checkAndAdd(p, tool, this, "ender", isCommand);
     }
 
@@ -105,18 +106,23 @@ public class Ender extends Modifier implements Craftable, Listener {
     @EventHandler
     public void effect(MTProjectileHitEvent event) {
         if (!this.isAllowed()) return;
+
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
+
         if (!p.hasPermission("minetinker.modifiers.ender.use")) return;
         if (!modManager.hasMod(tool, this)) return;
         if (!p.isSneaking()) return;
 
         Location loc = event.getEvent().getEntity().getLocation().clone(); //Location of the Arrow
         Location oldLoc = p.getLocation();
+
         p.teleport(new Location(loc.getWorld(), loc.getX(), loc.getY(), loc.getZ(), p.getLocation().getYaw(), p.getLocation().getPitch()).add(0, 1, 0));
+
         if (this.hasSound) {
             p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ENDERMAN_TELEPORT, 1.0F, 0.3F);
         }
+
         if (this.hasParticles) {
             AreaEffectCloud cloud = (AreaEffectCloud) p.getWorld().spawnEntity(p.getLocation(), EntityType.AREA_EFFECT_CLOUD);
             cloud.setVelocity(new Vector(0, 1, 0));
@@ -124,6 +130,7 @@ public class Ender extends Modifier implements Craftable, Listener {
             cloud.setDuration(5);
             cloud.setColor(Color.GREEN);
             cloud.getLocation().setYaw(90);
+
             AreaEffectCloud cloud2 = (AreaEffectCloud) p.getWorld().spawnEntity(oldLoc, EntityType.AREA_EFFECT_CLOUD);
             cloud2.setVelocity(new Vector(0, 1, 0));
             cloud2.setRadius(0.5f);
@@ -141,21 +148,25 @@ public class Ender extends Modifier implements Craftable, Listener {
     @EventHandler
     public void effect(MTEntityDamageByEntityEvent event) {
         if (event.isCancelled() || !this.isAllowed()) return;
+
         Player p = event.getPlayer();
+        if (!p.isSneaking()) return;
         if (p.equals(event.getEvent().getEntity())) return;
-        ItemStack tool = event.getTool();
         if (!p.hasPermission("minetinker.modifiers.ender.use")) return;
+
+        ItemStack tool = event.getTool();
         if (!modManager.hasMod(tool, this)) return; //No check needed, as Ender can only be applied on the Bow
         if (modManager.getModLevel(tool, this) < 2) return;
-        if (!p.isSneaking()) return;
 
         Location loc = event.getEvent().getEntity().getLocation().clone();
         event.getEvent().getEntity().teleport(p.getLocation());
         p.teleport(new Location(loc.getWorld(), loc.getX(), loc.getY(), loc.getZ()));
+
         if (this.hasSound) {
             p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ENDERMAN_TELEPORT, 1.0F, 0.3F); //Sound at Players position
             p.getWorld().playSound(event.getEvent().getEntity().getLocation(), Sound.ENTITY_ENDERMAN_TELEPORT, 1.0F, 0.3F); //Sound at Entity's position
         }
+
         ChatWriter.log(false, p.getDisplayName() + " triggered Ender on " + ItemGenerator.getDisplayName(tool) + ChatColor.GRAY + " (" + tool.getType().toString() + ")!");
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Ender.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Ender.java
@@ -104,12 +104,12 @@ public class Ender extends Modifier implements Craftable, Listener {
      */
     @EventHandler
     public void effect(MTProjectileHitEvent event) {
-        if (!this.isAllowed()) { return; }
+        if (!this.isAllowed()) return;
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
-        if (!p.hasPermission("minetinker.modifiers.ender.use")) { return; }
-        if (!modManager.hasMod(tool, this)) { return; }
-        if (!p.isSneaking()) { return; }
+        if (!p.hasPermission("minetinker.modifiers.ender.use")) return;
+        if (!modManager.hasMod(tool, this)) return;
+        if (!p.isSneaking()) return;
 
         Location loc = event.getEvent().getEntity().getLocation().clone(); //Location of the Arrow
         Location oldLoc = p.getLocation();
@@ -140,14 +140,14 @@ public class Ender extends Modifier implements Craftable, Listener {
      */
     @EventHandler
     public void effect(MTEntityDamageByEntityEvent event) {
-        if (event.isCancelled() || !this.isAllowed()) { return; }
+        if (event.isCancelled() || !this.isAllowed()) return;
         Player p = event.getPlayer();
-        if (p.equals(event.getEvent().getEntity())) { return; }
+        if (p.equals(event.getEvent().getEntity())) return;
         ItemStack tool = event.getTool();
-        if (!p.hasPermission("minetinker.modifiers.ender.use")) { return; }
-        if (!modManager.hasMod(tool, this)) { return; } //No check needed, as Ender can only be applied on the Bow
-        if (modManager.getModLevel(tool, this) < 2) { return; }
-        if (!p.isSneaking()) { return; }
+        if (!p.hasPermission("minetinker.modifiers.ender.use")) return;
+        if (!modManager.hasMod(tool, this)) return; //No check needed, as Ender can only be applied on the Bow
+        if (modManager.getModLevel(tool, this) < 2) return;
+        if (!p.isSneaking()) return;
 
         Location loc = event.getEvent().getEntity().getLocation().clone();
         event.getEvent().getEntity().teleport(p.getLocation());

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Experienced.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Experienced.java
@@ -44,6 +44,7 @@ public class Experienced extends Modifier implements Craftable, Listener {
                                                 ToolType.SWORD, ToolType.TRIDENT, ToolType.FISHINGROD,
                                                 ToolType.HELMET, ToolType.CHESTPLATE, ToolType.LEGGINGS, ToolType.BOOTS, ToolType.ELYTRA)),
                 Main.getPlugin());
+
         Bukkit.getPluginManager().registerEvents(this, Main.getPlugin());
     }
 
@@ -93,22 +94,26 @@ public class Experienced extends Modifier implements Craftable, Listener {
     @EventHandler
     public void effect(MTEntityDamageByEntityEvent event) {
         if (event.isCancelled() || !this.isAllowed()) return;
+
         if (ToolType.BOOTS.getMaterials().contains(event.getTool().getType())
             || ToolType.LEGGINGS.getMaterials().contains(event.getTool().getType())
             || ToolType.CHESTPLATE.getMaterials().contains(event.getTool().getType())
             || ToolType.HELMET.getMaterials().contains(event.getTool().getType())) return; //Makes sure that armor does not get the double effect as it also gets the effect in EntityDamageEvent
+
         effect(event.getPlayer(), event.getTool());
     }
 
     @EventHandler
     public void effect(MTEntityDamageEvent event) {
         if (event.isCancelled() || !this.isAllowed()) return;
+
         effect(event.getPlayer(), event.getTool());
     }
 
     @EventHandler
     public void effect(MTPlayerInteractEvent event) {
         if (event.isCancelled() || !this.isAllowed()) return;
+
         effect(event.getPlayer(), event.getTool());
     }
 
@@ -125,6 +130,7 @@ public class Experienced extends Modifier implements Craftable, Listener {
 
         Random rand = new Random();
         int n = rand.nextInt(100);
+
         if (n <= this.percentagePerLevel * level) {
             ExperienceOrb orb = p.getWorld().spawn(p.getLocation(), ExperienceOrb.class);
             orb.setExperience(this.amount);

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Experienced.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Experienced.java
@@ -86,29 +86,29 @@ public class Experienced extends Modifier implements Craftable, Listener {
 
     @EventHandler
     public void effect(MTBlockBreakEvent event) {
-        if (event.isCancelled() || !this.isAllowed()) { return; }
+        if (event.isCancelled() || !this.isAllowed()) return;
         effect(event.getPlayer(), event.getTool());
     }
 
     @EventHandler
     public void effect(MTEntityDamageByEntityEvent event) {
-        if (event.isCancelled() || !this.isAllowed()) { return; }
+        if (event.isCancelled() || !this.isAllowed()) return;
         if (ToolType.BOOTS.getMaterials().contains(event.getTool().getType())
             || ToolType.LEGGINGS.getMaterials().contains(event.getTool().getType())
             || ToolType.CHESTPLATE.getMaterials().contains(event.getTool().getType())
-            || ToolType.HELMET.getMaterials().contains(event.getTool().getType())) { return; } //Makes sure that armor does not get the double effect as it also gets the effect in EntityDamageEvent
+            || ToolType.HELMET.getMaterials().contains(event.getTool().getType())) return; //Makes sure that armor does not get the double effect as it also gets the effect in EntityDamageEvent
         effect(event.getPlayer(), event.getTool());
     }
 
     @EventHandler
     public void effect(MTEntityDamageEvent event) {
-        if (event.isCancelled() || !this.isAllowed()) { return; }
+        if (event.isCancelled() || !this.isAllowed()) return;
         effect(event.getPlayer(), event.getTool());
     }
 
     @EventHandler
     public void effect(MTPlayerInteractEvent event) {
-        if (event.isCancelled() || !this.isAllowed()) { return; }
+        if (event.isCancelled() || !this.isAllowed()) return;
         effect(event.getPlayer(), event.getTool());
     }
 
@@ -118,8 +118,8 @@ public class Experienced extends Modifier implements Craftable, Listener {
      * @param tool the Tool
      */
     private void effect(Player p, ItemStack tool) {
-        if (!p.hasPermission("minetinker.modifiers.experienced.use")) { return; }
-        if (!modManager.hasMod(tool, this)) { return; }
+        if (!p.hasPermission("minetinker.modifiers.experienced.use")) return;
+        if (!modManager.hasMod(tool, this)) return;
 
         int level = modManager.getModLevel(tool, this);
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Experienced.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Experienced.java
@@ -16,6 +16,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.ExperienceOrb;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -24,6 +25,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 public class Experienced extends Modifier implements Craftable, Listener {
@@ -46,6 +48,13 @@ public class Experienced extends Modifier implements Craftable, Listener {
                 Main.getPlugin());
 
         Bukkit.getPluginManager().registerEvents(this, Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/ExtraModifier.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/ExtraModifier.java
@@ -65,12 +65,14 @@ public class ExtraModifier extends Modifier {
             pluginManager.callEvent(new ModifierFailEvent(p, tool, this, ModifierFailCause.NO_PERMISSION, isCommand));
             return null;
         }
+
         if (!getAllowedTools().contains(ToolType.get(tool.getType()))) {
             pluginManager.callEvent(new ModifierFailEvent(p, tool, this, ModifierFailCause.INVALID_TOOLTYPE, isCommand));
             return null;
         }
 
         int slotsRemaining = modManager.getFreeSlots(tool);
+
         if (slotsRemaining + gain == Integer.MAX_VALUE || slotsRemaining + gain < 0) {
             pluginManager.callEvent(new ModifierFailEvent(p, tool, this, ModifierFailCause.MAXIMUM_SLOTS_REACHED, isCommand));
             return null;
@@ -78,6 +80,7 @@ public class ExtraModifier extends Modifier {
         int amount = slotsRemaining + gain;
 
         modManager.setFreeSlots(tool, amount);
+
         return tool;
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/ExtraModifier.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/ExtraModifier.java
@@ -10,11 +10,13 @@ import de.flo56958.MineTinker.Utilities.ConfigurationManager;
 import de.flo56958.MineTinker.Utilities.Modifiers_Config;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class ExtraModifier extends Modifier {
 
@@ -33,6 +35,13 @@ public class ExtraModifier extends Modifier {
                                                 ToolType.SHOVEL, ToolType.SWORD, ToolType.TRIDENT,
                                                 ToolType.HELMET, ToolType.CHESTPLATE, ToolType.LEGGINGS, ToolType.BOOTS, ToolType.ELYTRA)),
                 Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Fiery.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Fiery.java
@@ -69,32 +69,38 @@ public class Fiery extends Modifier implements Enchantable, Craftable {
 
         ItemMeta meta = tool.getItemMeta();
 
-        if (ToolType.BOW.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.ARROW_FIRE, modManager.getModLevel(tool, this), true);
-        } else if (ToolType.SWORD.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.FIRE_ASPECT, modManager.getModLevel(tool, this), true);
-        }
-        if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
-            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-        } else {
-            meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+        if (meta != null) {
+            if (ToolType.BOW.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.ARROW_FIRE, modManager.getModLevel(tool, this), true);
+            } else if (ToolType.SWORD.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.FIRE_ASPECT, modManager.getModLevel(tool, this), true);
+            }
+            if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            } else {
+                meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+            }
+
+            tool.setItemMeta(meta);
         }
 
-        tool.setItemMeta(meta);
         return tool;
     }
 
     @Override
     public void removeMod(ItemStack tool) {
         ItemMeta meta = tool.getItemMeta();
-        meta.removeEnchant(Enchantment.FIRE_ASPECT);
-        meta.removeEnchant(Enchantment.ARROW_FIRE);
-        tool.setItemMeta(meta);
+
+        if (meta != null) {
+            meta.removeEnchant(Enchantment.FIRE_ASPECT);
+            meta.removeEnchant(Enchantment.ARROW_FIRE);
+            tool.setItemMeta(meta);
+        }
     }
 
     @Override
     public void enchantItem(Player p, ItemStack item) {
-        if (!p.hasPermission("minetinker.modifiers.fiery.craft")) { return; }
+        if (!p.hasPermission("minetinker.modifiers.fiery.craft")) return;
         _createModifierItem(getConfig(), p, this, "Fiery");
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Fiery.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Fiery.java
@@ -75,6 +75,7 @@ public class Fiery extends Modifier implements Enchantable, Craftable {
             } else if (ToolType.SWORD.getMaterials().contains(tool.getType())) {
                 meta.addEnchant(Enchantment.FIRE_ASPECT, modManager.getModLevel(tool, this), true);
             }
+
             if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
                 meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             } else {

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Fiery.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Fiery.java
@@ -18,6 +18,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class Fiery extends Modifier implements Enchantable, Craftable {
 
@@ -33,6 +34,15 @@ public class Fiery extends Modifier implements Enchantable, Craftable {
         super(ModifierType.FIERY,
                 new ArrayList<>(Arrays.asList(ToolType.AXE, ToolType.BOW, ToolType.SWORD)),
                 Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+        enchantments.add(Enchantment.ARROW_FIRE);
+        enchantments.add(Enchantment.FIRE_ASPECT);
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Freezing.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Freezing.java
@@ -80,12 +80,15 @@ public class Freezing extends Modifier implements Craftable {
         }
 
         ItemMeta meta = tool.getItemMeta();
-        meta.addEnchant(Enchantment.FROST_WALKER, modManager.getModLevel(tool, this), true);
 
-        if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
-            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-        } else {
-            meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+        if (meta != null) {
+            meta.addEnchant(Enchantment.FROST_WALKER, modManager.getModLevel(tool, this), true);
+
+            if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            } else {
+                meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+            }
         }
 
         tool.setItemMeta(meta);
@@ -95,8 +98,11 @@ public class Freezing extends Modifier implements Craftable {
     @Override
     public void removeMod(ItemStack tool) {
         ItemMeta meta = tool.getItemMeta();
-        meta.removeEnchant(Enchantment.FROST_WALKER);
-        tool.setItemMeta(meta);
+
+        if (meta != null) {
+            meta.removeEnchant(Enchantment.FROST_WALKER);
+            tool.setItemMeta(meta);
+        }
     }
 
     private static FileConfiguration getConfig() {

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Freezing.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Freezing.java
@@ -19,6 +19,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 public class Freezing extends Modifier implements Craftable {
 
@@ -33,6 +34,14 @@ public class Freezing extends Modifier implements Craftable {
         super(ModifierType.FREEZING,
                 new ArrayList<>(Collections.singletonList(ToolType.BOOTS)),
                 Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+        enchantments.add(Enchantment.FROST_WALKER);
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Glowing.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Glowing.java
@@ -93,7 +93,6 @@ public class Glowing extends Modifier implements Craftable, Listener {
 
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
-
         LivingEntity e = (LivingEntity) event.getEntity();
 
         if (!p.hasPermission("minetinker.modifiers.glowing.use")) return;
@@ -101,6 +100,7 @@ public class Glowing extends Modifier implements Craftable, Listener {
 
         int duration = (int) (this.duration * Math.pow(this.durationMultiplier, (modManager.getModLevel(tool, this) - 1)));
         e.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, duration, 0, false, false));
+
         ChatWriter.log(false, p.getDisplayName() + " triggered Glowing on " + ItemGenerator.getDisplayName(tool) + ChatColor.GRAY + " (" + tool.getType().toString() + ")!");
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Glowing.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Glowing.java
@@ -88,16 +88,16 @@ public class Glowing extends Modifier implements Craftable, Listener {
 
     @EventHandler
     public void effect(MTEntityDamageByEntityEvent event) {
-        if (event.isCancelled() || !this.isAllowed()) { return; }
-        if (!(event.getEntity() instanceof LivingEntity)) { return; }
+        if (event.isCancelled() || !this.isAllowed()) return;
+        if (!(event.getEntity() instanceof LivingEntity)) return;
 
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
 
         LivingEntity e = (LivingEntity) event.getEntity();
 
-        if (!p.hasPermission("minetinker.modifiers.glowing.use")) { return; }
-        if (!modManager.hasMod(tool, this)) { return; }
+        if (!p.hasPermission("minetinker.modifiers.glowing.use")) return;
+        if (!modManager.hasMod(tool, this)) return;
 
         int duration = (int) (this.duration * Math.pow(this.durationMultiplier, (modManager.getModLevel(tool, this) - 1)));
         e.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, duration, 0, false, false));

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Glowing.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Glowing.java
@@ -13,6 +13,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -23,6 +24,7 @@ import org.bukkit.potion.PotionEffectType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class Glowing extends Modifier implements Craftable, Listener {
 
@@ -41,6 +43,13 @@ public class Glowing extends Modifier implements Craftable, Listener {
                 new ArrayList<>(Arrays.asList(ToolType.AXE, ToolType.BOW, ToolType.SWORD, ToolType.TRIDENT)),
                 Main.getPlugin());
         Bukkit.getPluginManager().registerEvents(this, Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Haste.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Haste.java
@@ -17,6 +17,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class Haste extends Modifier implements Craftable {
 
@@ -31,6 +32,15 @@ public class Haste extends Modifier implements Craftable {
         super(ModifierType.HASTE,
                 new ArrayList<>(Arrays.asList(ToolType.AXE, ToolType.PICKAXE, ToolType.SHOVEL, ToolType.SHEARS, ToolType.FISHINGROD)),
                 Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+        enchantments.add(Enchantment.LURE);
+        enchantments.add(Enchantment.DIG_SPEED);
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Haste.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Haste.java
@@ -70,17 +70,19 @@ public class Haste extends Modifier implements Craftable {
 
         ItemMeta meta = tool.getItemMeta();
 
-        if (ToolType.FISHINGROD.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.LURE, modManager.getModLevel(tool, this), true);
-        } else {
-            meta.addEnchant(Enchantment.DIG_SPEED, modManager.getModLevel(tool, this), true);
+        if (meta != null) {
+            if (ToolType.FISHINGROD.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.LURE, modManager.getModLevel(tool, this), true);
+            } else {
+                meta.addEnchant(Enchantment.DIG_SPEED, modManager.getModLevel(tool, this), true);
+            }
+            if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            } else {
+                meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+            }
+            tool.setItemMeta(meta);
         }
-        if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
-            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-        } else {
-            meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
-        }
-        tool.setItemMeta(meta);
 
         return tool;
     }
@@ -88,9 +90,12 @@ public class Haste extends Modifier implements Craftable {
     @Override
     public void removeMod(ItemStack tool) {
         ItemMeta meta = tool.getItemMeta();
-        meta.removeEnchant(Enchantment.DIG_SPEED);
-        meta.removeEnchant(Enchantment.LURE);
-        tool.setItemMeta(meta);
+
+        if (meta != null) {
+            meta.removeEnchant(Enchantment.DIG_SPEED);
+            meta.removeEnchant(Enchantment.LURE);
+            tool.setItemMeta(meta);
+        }
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Haste.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Haste.java
@@ -76,6 +76,7 @@ public class Haste extends Modifier implements Craftable {
             } else {
                 meta.addEnchant(Enchantment.DIG_SPEED, modManager.getModLevel(tool, this), true);
             }
+
             if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
                 meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             } else {

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Infinity.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Infinity.java
@@ -86,18 +86,21 @@ public class Infinity extends Modifier implements Enchantable, Craftable {
 
         ItemMeta meta = tool.getItemMeta();
 
-        if (ToolType.BOW.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.ARROW_INFINITE, modManager.getModLevel(tool, this), true);
-        } else if (ToolType.TRIDENT.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.LOYALTY, modManager.getModLevel(tool, this), true);
-        }
-        if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
-            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-        } else {
-            meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+        if (meta != null) {
+            if (ToolType.BOW.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.ARROW_INFINITE, modManager.getModLevel(tool, this), true);
+            } else if (ToolType.TRIDENT.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.LOYALTY, modManager.getModLevel(tool, this), true);
+            }
+            if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            } else {
+                meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+            }
+
+            tool.setItemMeta(meta);
         }
 
-        tool.setItemMeta(meta);
 
         return tool;
     }
@@ -105,14 +108,17 @@ public class Infinity extends Modifier implements Enchantable, Craftable {
     @Override
     public void removeMod(ItemStack tool) {
         ItemMeta meta = tool.getItemMeta();
-        meta.removeEnchant(Enchantment.ARROW_INFINITE);
-        meta.removeEnchant(Enchantment.LOYALTY);
-        tool.setItemMeta(meta);
+
+        if (meta != null) {
+            meta.removeEnchant(Enchantment.ARROW_INFINITE);
+            meta.removeEnchant(Enchantment.LOYALTY);
+            tool.setItemMeta(meta);
+        }
     }
 
     @Override
     public void enchantItem(Player p, ItemStack item) {
-        if (!p.hasPermission("minetinker.modifiers.infinity.craft")) { return; }
+        if (!p.hasPermission("minetinker.modifiers.infinity.craft")) return;
         _createModifierItem(getConfig(), p, this, "Infinity");
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Infinity.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Infinity.java
@@ -92,6 +92,7 @@ public class Infinity extends Modifier implements Enchantable, Craftable {
             } else if (ToolType.TRIDENT.getMaterials().contains(tool.getType())) {
                 meta.addEnchant(Enchantment.LOYALTY, modManager.getModLevel(tool, this), true);
             }
+
             if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
                 meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             } else {

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Infinity.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Infinity.java
@@ -20,6 +20,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class Infinity extends Modifier implements Enchantable, Craftable {
 
@@ -36,6 +37,15 @@ public class Infinity extends Modifier implements Enchantable, Craftable {
         super(ModifierType.INFINITY,
                 new ArrayList<>(Arrays.asList(ToolType.BOW, ToolType.TRIDENT)),
                 Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+        enchantments.add(Enchantment.ARROW_INFINITE);
+        enchantments.add(Enchantment.LOYALTY);
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Knockback.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Knockback.java
@@ -76,6 +76,7 @@ public class Knockback extends Modifier implements Enchantable, Craftable {
             } else if (ToolType.SWORD.getMaterials().contains(tool.getType())) {
                 meta.addEnchant(Enchantment.KNOCKBACK, modManager.getModLevel(tool, this), true);
             }
+
             if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
                 meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             } else {

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Knockback.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Knockback.java
@@ -18,6 +18,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class Knockback extends Modifier implements Enchantable, Craftable {
 
@@ -32,6 +33,15 @@ public class Knockback extends Modifier implements Enchantable, Craftable {
         super(ModifierType.KNOCKBACK,
                 new ArrayList<>(Arrays.asList(ToolType.AXE, ToolType.BOW, ToolType.SWORD, ToolType.TRIDENT)),
                 Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+        enchantments.add(Enchantment.KNOCKBACK);
+        enchantments.add(Enchantment.ARROW_KNOCKBACK);
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Knockback.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Knockback.java
@@ -68,19 +68,21 @@ public class Knockback extends Modifier implements Enchantable, Craftable {
 
         ItemMeta meta = tool.getItemMeta();
 
-        if (ToolType.AXE.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.KNOCKBACK, modManager.getModLevel(tool, this), true);
-        } else if (ToolType.BOW.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.ARROW_KNOCKBACK, modManager.getModLevel(tool, this), true);
-        } else if (ToolType.SWORD.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.KNOCKBACK, modManager.getModLevel(tool, this), true);
+        if (meta != null) {
+            if (ToolType.AXE.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.KNOCKBACK, modManager.getModLevel(tool, this), true);
+            } else if (ToolType.BOW.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.ARROW_KNOCKBACK, modManager.getModLevel(tool, this), true);
+            } else if (ToolType.SWORD.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.KNOCKBACK, modManager.getModLevel(tool, this), true);
+            }
+            if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            } else {
+                meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+            }
+            tool.setItemMeta(meta);
         }
-        if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
-            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-        } else {
-            meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
-        }
-        tool.setItemMeta(meta);
 
         return tool;
     }
@@ -88,14 +90,17 @@ public class Knockback extends Modifier implements Enchantable, Craftable {
     @Override
     public void removeMod(ItemStack tool) {
         ItemMeta meta = tool.getItemMeta();
-        meta.removeEnchant(Enchantment.KNOCKBACK);
-        meta.removeEnchant(Enchantment.ARROW_KNOCKBACK);
-        tool.setItemMeta(meta);
+
+        if (meta != null) {
+            meta.removeEnchant(Enchantment.KNOCKBACK);
+            meta.removeEnchant(Enchantment.ARROW_KNOCKBACK);
+            tool.setItemMeta(meta);
+        }
     }
 
     @Override
     public void enchantItem(Player p, ItemStack item) {
-        if (!p.hasPermission("minetinker.modifiers.knockback.craft")) { return; }
+        if (!p.hasPermission("minetinker.modifiers.knockback.craft")) return;
         _createModifierItem(getConfig(), p, this, "Knockback");
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Lifesteal.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Lifesteal.java
@@ -85,8 +85,8 @@ public class Lifesteal extends Modifier implements Craftable, Listener {
 
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
-        if (!p.hasPermission("minetinker.modifiers.lifesteal.use")) return;
 
+        if (!p.hasPermission("minetinker.modifiers.lifesteal.use")) return;
         if (!modManager.hasMod(tool, this)) return;
 
         Random rand = new Random();
@@ -94,15 +94,13 @@ public class Lifesteal extends Modifier implements Craftable, Listener {
 
         int level = modManager.getModLevel(tool, this);
         double damage = event.getEvent().getDamage();
-
         double recovery = damage * ((percentPerLevel * level) / 100.0);
-
         double health = p.getHealth() + recovery;
 
         // TODO: don't call getMaxHealth
         if (health > p.getMaxHealth()) { health = p.getMaxHealth(); } // for IllegalArgumentExeption if Health is biggen than MaxHealth
-
         p.setHealth(health);
+
         ChatWriter.log(false, p.getDisplayName() + " triggered Lifesteal on " + ItemGenerator.getDisplayName(tool) + ChatColor.GRAY + " (" + tool.getType().toString() + ") and got " + recovery + " health back!");
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Lifesteal.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Lifesteal.java
@@ -80,17 +80,17 @@ public class Lifesteal extends Modifier implements Craftable, Listener {
 
     @EventHandler(priority = EventPriority.HIGH) //because of Melting
     public void effect(MTEntityDamageByEntityEvent event) {
-        if (event.isCancelled() || !this.isAllowed()) { return; }
-        if (event.getPlayer().equals(event.getEvent().getEntity())) { return; } //when event was triggered by the armor
+        if (event.isCancelled() || !this.isAllowed()) return;
+        if (event.getPlayer().equals(event.getEvent().getEntity())) return; //when event was triggered by the armor
 
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
-        if (!p.hasPermission("minetinker.modifiers.lifesteal.use")) { return; }
+        if (!p.hasPermission("minetinker.modifiers.lifesteal.use")) return;
 
-        if (!modManager.hasMod(tool, this)) { return; }
+        if (!modManager.hasMod(tool, this)) return;
 
         Random rand = new Random();
-        if (rand.nextInt(100) > this.percentToTrigger) { return; }
+        if (rand.nextInt(100) > this.percentToTrigger) return;
 
         int level = modManager.getModLevel(tool, this);
         double damage = event.getEvent().getDamage();
@@ -99,6 +99,7 @@ public class Lifesteal extends Modifier implements Craftable, Listener {
 
         double health = p.getHealth() + recovery;
 
+        // TODO: don't call getMaxHealth
         if (health > p.getMaxHealth()) { health = p.getMaxHealth(); } // for IllegalArgumentExeption if Health is biggen than MaxHealth
 
         p.setHealth(health);

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Lifesteal.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Lifesteal.java
@@ -13,6 +13,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -21,6 +22,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 public class Lifesteal extends Modifier implements Craftable, Listener {
@@ -40,6 +42,13 @@ public class Lifesteal extends Modifier implements Craftable, Listener {
                 new ArrayList<>(Arrays.asList(ToolType.AXE, ToolType.BOW, ToolType.SWORD, ToolType.TRIDENT)),
                 Main.getPlugin());
         Bukkit.getPluginManager().registerEvents(this, Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/LightWeight.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/LightWeight.java
@@ -75,6 +75,7 @@ public class LightWeight extends Modifier implements Enchantable, Craftable {
             } else {
                 meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
             }
+
             tool.setItemMeta(meta);
         }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/LightWeight.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/LightWeight.java
@@ -68,13 +68,15 @@ public class LightWeight extends Modifier implements Enchantable, Craftable {
 
         ItemMeta meta = tool.getItemMeta();
 
-        meta.addEnchant(Enchantment.PROTECTION_FALL, modManager.getModLevel(tool, this), true);
-        if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
-            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-        } else {
-            meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+        if (meta != null) {
+            meta.addEnchant(Enchantment.PROTECTION_FALL, modManager.getModLevel(tool, this), true);
+            if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            } else {
+                meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+            }
+            tool.setItemMeta(meta);
         }
-        tool.setItemMeta(meta);
 
         return tool;
     }
@@ -82,13 +84,16 @@ public class LightWeight extends Modifier implements Enchantable, Craftable {
     @Override
     public void removeMod(ItemStack tool) {
         ItemMeta meta = tool.getItemMeta();
-        meta.removeEnchant(Enchantment.PROTECTION_FALL);
-        tool.setItemMeta(meta);
+
+        if (meta != null) {
+            meta.removeEnchant(Enchantment.PROTECTION_FALL);
+            tool.setItemMeta(meta);
+        }
     }
 
     @Override
     public void enchantItem(Player p, ItemStack item) {
-        if (!p.hasPermission("minetinker.modifiers.lightweight.craft")) { return; }
+        if (!p.hasPermission("minetinker.modifiers.lightweight.craft")) return;
         _createModifierItem(getConfig(), p, this, "Light-Weight");
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/LightWeight.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/LightWeight.java
@@ -18,6 +18,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 public class LightWeight extends Modifier implements Enchantable, Craftable {
 
@@ -32,6 +33,14 @@ public class LightWeight extends Modifier implements Enchantable, Craftable {
         super(ModifierType.LIGHT_WEIGHT,
                 new ArrayList<>(Collections.singletonList(ToolType.BOOTS)),
                 Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+        enchantments.add(Enchantment.PROTECTION_FALL);
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Luck.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Luck.java
@@ -98,6 +98,7 @@ public class Luck extends Modifier implements Craftable {
             } else if (ToolType.FISHINGROD.getMaterials().contains(tool.getType())) {
                 meta.addEnchant(Enchantment.LUCK, modManager.getModLevel(tool, this), true);
             }
+
             if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
                 meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             } else {

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Luck.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Luck.java
@@ -19,6 +19,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class Luck extends Modifier implements Craftable {
 
@@ -34,6 +35,16 @@ public class Luck extends Modifier implements Craftable {
                 new ArrayList<>(Arrays.asList(ToolType.AXE, ToolType.BOW, ToolType.HOE, ToolType.PICKAXE, ToolType.SHEARS,
                         ToolType.FISHINGROD, ToolType.SHOVEL, ToolType.SWORD, ToolType.TRIDENT)),
                 Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+        enchantments.add(Enchantment.LOOT_BONUS_BLOCKS);
+        enchantments.add(Enchantment.LOOT_BONUS_MOBS);
+        enchantments.add(Enchantment.LUCK);
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Luck.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Luck.java
@@ -79,31 +79,33 @@ public class Luck extends Modifier implements Craftable {
 
         ItemMeta meta = tool.getItemMeta();
 
-        if (ToolType.AXE.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.LOOT_BONUS_BLOCKS, modManager.getModLevel(tool, this), true);
-            meta.addEnchant(Enchantment.LOOT_BONUS_MOBS, modManager.getModLevel(tool, this), true);
-        } else if (ToolType.BOW.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.LOOT_BONUS_MOBS, modManager.getModLevel(tool, this), true);
-        } else if (ToolType.HOE.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.LOOT_BONUS_BLOCKS, modManager.getModLevel(tool, this), true);
-        } else if (ToolType.PICKAXE.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.LOOT_BONUS_BLOCKS, modManager.getModLevel(tool, this), true);
-        } else if (ToolType.SHOVEL.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.LOOT_BONUS_BLOCKS, modManager.getModLevel(tool, this), true);
-        } else if (ToolType.SWORD.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.LOOT_BONUS_MOBS, modManager.getModLevel(tool, this), true);
-        } else if (ToolType.SHEARS.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.LOOT_BONUS_BLOCKS, modManager.getModLevel(tool, this), true);
-        } else if (ToolType.FISHINGROD.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.LUCK, modManager.getModLevel(tool, this), true);
-        }
-        if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
-            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-        } else {
-            meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
-        }
+        if (meta != null) {
+            if (ToolType.AXE.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.LOOT_BONUS_BLOCKS, modManager.getModLevel(tool, this), true);
+                meta.addEnchant(Enchantment.LOOT_BONUS_MOBS, modManager.getModLevel(tool, this), true);
+            } else if (ToolType.BOW.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.LOOT_BONUS_MOBS, modManager.getModLevel(tool, this), true);
+            } else if (ToolType.HOE.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.LOOT_BONUS_BLOCKS, modManager.getModLevel(tool, this), true);
+            } else if (ToolType.PICKAXE.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.LOOT_BONUS_BLOCKS, modManager.getModLevel(tool, this), true);
+            } else if (ToolType.SHOVEL.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.LOOT_BONUS_BLOCKS, modManager.getModLevel(tool, this), true);
+            } else if (ToolType.SWORD.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.LOOT_BONUS_MOBS, modManager.getModLevel(tool, this), true);
+            } else if (ToolType.SHEARS.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.LOOT_BONUS_BLOCKS, modManager.getModLevel(tool, this), true);
+            } else if (ToolType.FISHINGROD.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.LUCK, modManager.getModLevel(tool, this), true);
+            }
+            if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            } else {
+                meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+            }
 
-        tool.setItemMeta(meta);
+            tool.setItemMeta(meta);
+        }
 
         return tool;
     }
@@ -111,10 +113,13 @@ public class Luck extends Modifier implements Craftable {
     @Override
     public void removeMod(ItemStack tool) {
         ItemMeta meta = tool.getItemMeta();
-        meta.removeEnchant(Enchantment.LOOT_BONUS_BLOCKS);
-        meta.removeEnchant(Enchantment.LOOT_BONUS_MOBS);
-        meta.removeEnchant(Enchantment.LUCK);
-        tool.setItemMeta(meta);
+
+        if (meta != null) {
+            meta.removeEnchant(Enchantment.LOOT_BONUS_BLOCKS);
+            meta.removeEnchant(Enchantment.LOOT_BONUS_MOBS);
+            meta.removeEnchant(Enchantment.LUCK);
+            tool.setItemMeta(meta);
+        }
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Melting.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Melting.java
@@ -89,6 +89,7 @@ public class Melting extends Modifier implements Enchantable, Craftable, Listene
 
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
+
         if (!p.hasPermission("minetinker.modifiers.melting.use")) return;
         if (!modManager.hasMod(tool, this)) return;
 
@@ -102,8 +103,10 @@ public class Melting extends Modifier implements Enchantable, Craftable, Listene
             if (p.getFireTicks() > 0 && cancelBurning) {
                 p.setFireTicks(0);
             }
+
             double damage = event.getEvent().getDamage();
             damage = damage * (1 - this.bonusMultiplier * level);
+
             event.getEvent().setDamage(damage);
 
             ChatWriter.log(false, p.getDisplayName() + " triggered Melting on " + ItemGenerator.getDisplayName(tool) + ChatColor.GRAY + " (" + tool.getType().toString() + ")!");
@@ -113,13 +116,14 @@ public class Melting extends Modifier implements Enchantable, Craftable, Listene
              */
             if (event.getEvent().getEntity() instanceof LivingEntity) {
                 LivingEntity e = (LivingEntity) event.getEvent().getEntity();
+
                 if (e.isDead()) return;
                 int level = modManager.getModLevel(tool, this);
-
                 if (e.getFireTicks() == 0) return;
 
                 double damage = event.getEvent().getDamage();
                 damage = damage * (1 + this.bonusMultiplier * level);
+
                 event.getEvent().setDamage(damage);
 
                 ChatWriter.log(false, p.getDisplayName() + " triggered Melting on " + ItemGenerator.getDisplayName(tool) + ChatColor.GRAY + " (" + tool.getType().toString() + ")!");
@@ -133,12 +137,14 @@ public class Melting extends Modifier implements Enchantable, Craftable, Listene
 
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
+
         if (!p.hasPermission("minetinker.modifiers.melting.use")) return;
         if (!modManager.hasMod(tool, this)) return;
 
         if (p.getFireTicks() > 0 && cancelBurning) {
             p.setFireTicks(0);
         }
+
         ChatWriter.log(false, p.getDisplayName() + " triggered Melting on " + ItemGenerator.getDisplayName(tool) + ChatColor.GRAY + " (" + tool.getType().toString() + ")!");
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Melting.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Melting.java
@@ -15,6 +15,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -23,6 +24,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class Melting extends Modifier implements Enchantable, Craftable, Listener {
 
@@ -42,6 +44,13 @@ public class Melting extends Modifier implements Enchantable, Craftable, Listene
                                                 ToolType.CHESTPLATE, ToolType.LEGGINGS)),
                 Main.getPlugin());
         Bukkit.getPluginManager().registerEvents(this, Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Melting.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Melting.java
@@ -85,19 +85,19 @@ public class Melting extends Modifier implements Enchantable, Craftable, Listene
 
     @EventHandler
     public void effect(MTEntityDamageByEntityEvent event) {
-        if (event.isCancelled() || !this.isAllowed()) { return; }
+        if (event.isCancelled() || !this.isAllowed()) return;
 
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
-        if (!p.hasPermission("minetinker.modifiers.melting.use")) { return; }
-        if (!modManager.hasMod(tool, this)) { return; }
+        if (!p.hasPermission("minetinker.modifiers.melting.use")) return;
+        if (!modManager.hasMod(tool, this)) return;
 
         if (event.getPlayer().equals(event.getEvent().getEntity())) {
             /*
             The melting effect if the Player gets damaged. getTool = Armor piece
              */
             int level = modManager.getModLevel(tool, this);
-            if (p.getFireTicks() <= 0) { return; }
+            if (p.getFireTicks() <= 0) return;
 
             if (p.getFireTicks() > 0 && cancelBurning) {
                 p.setFireTicks(0);
@@ -113,10 +113,10 @@ public class Melting extends Modifier implements Enchantable, Craftable, Listene
              */
             if (event.getEvent().getEntity() instanceof LivingEntity) {
                 LivingEntity e = (LivingEntity) event.getEvent().getEntity();
-                if (e.isDead()) { return; }
+                if (e.isDead()) return;
                 int level = modManager.getModLevel(tool, this);
 
-                if (e.getFireTicks() == 0) { return; }
+                if (e.getFireTicks() == 0) return;
 
                 double damage = event.getEvent().getDamage();
                 damage = damage * (1 + this.bonusMultiplier * level);
@@ -129,12 +129,12 @@ public class Melting extends Modifier implements Enchantable, Craftable, Listene
 
     @EventHandler
     public void effect(MTEntityDamageEvent event) {
-        if (event.isCancelled() || !this.isAllowed()) { return; }
+        if (event.isCancelled() || !this.isAllowed()) return;
 
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
-        if (!p.hasPermission("minetinker.modifiers.melting.use")) { return; }
-        if (!modManager.hasMod(tool, this)) { return; }
+        if (!p.hasPermission("minetinker.modifiers.melting.use")) return;
+        if (!modManager.hasMod(tool, this)) return;
 
         if (p.getFireTicks() > 0 && cancelBurning) {
             p.setFireTicks(0);
@@ -144,7 +144,7 @@ public class Melting extends Modifier implements Enchantable, Craftable, Listene
 
     @Override
     public void enchantItem(Player p, ItemStack item) {
-        if (!p.hasPermission("minetinker.modifiers.melting.craft")) { return; }
+        if (!p.hasPermission("minetinker.modifiers.melting.craft")) return;
         _createModifierItem(getConfig(), p, this, "Melting");
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Poisonous.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Poisonous.java
@@ -89,15 +89,15 @@ public class Poisonous extends Modifier implements Enchantable, Craftable, Liste
 
     @EventHandler
     public void effect(MTEntityDamageByEntityEvent event) {
-        if (event.isCancelled() || !this.isAllowed()) { return; }
+        if (event.isCancelled() || !this.isAllowed()) return;
 
-        if (!(event.getEntity() instanceof LivingEntity)) { return; }
+        if (!(event.getEntity() instanceof LivingEntity)) return;
 
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
 
-        if (!p.hasPermission("minetinker.modifiers.poisonous.use")) { return; }
-        if (!modManager.hasMod(tool, this)) { return; }
+        if (!p.hasPermission("minetinker.modifiers.poisonous.use")) return;
+        if (!modManager.hasMod(tool, this)) return;
 
         int level = modManager.getModLevel(tool, this);
 
@@ -109,7 +109,7 @@ public class Poisonous extends Modifier implements Enchantable, Craftable, Liste
 
     @Override
     public void enchantItem(Player p, ItemStack item) {
-        if (!p.hasPermission("minetinker.modifiers.poisonous.craft")) { return; }
+        if (!p.hasPermission("minetinker.modifiers.poisonous.craft")) return;
         _createModifierItem(getConfig(), p, this, "Poisonous");
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Poisonous.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Poisonous.java
@@ -15,6 +15,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -27,6 +28,7 @@ import org.bukkit.potion.PotionEffectType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 
 public class Poisonous extends Modifier implements Enchantable, Craftable, Listener {
 	
@@ -48,6 +50,13 @@ public class Poisonous extends Modifier implements Enchantable, Craftable, Liste
                                                 ToolType.HELMET, ToolType.CHESTPLATE, ToolType.LEGGINGS, ToolType.BOOTS, ToolType.ELYTRA)),
                 Main.getPlugin());
         Bukkit.getPluginManager().registerEvents(this, Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Poisonous.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Poisonous.java
@@ -87,10 +87,9 @@ public class Poisonous extends Modifier implements Enchantable, Craftable, Liste
     @Override
     public void removeMod(ItemStack tool) { }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void effect(MTEntityDamageByEntityEvent event) {
-        if (event.isCancelled() || !this.isAllowed()) return;
-
+        if (!this.isAllowed()) return;
         if (!(event.getEntity() instanceof LivingEntity)) return;
 
         Player p = event.getPlayer();

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Portalized.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Portalized.java
@@ -66,6 +66,7 @@ public class Portalized extends Modifier implements Craftable, Listener {
             pluginManager.callEvent(new ModifierFailEvent(p, tool, this, ModifierFailCause.INCOMPATIBLE_MODIFIERS, isCommand));
             return null;
         }
+
         return Modifier.checkAndAdd(p, tool, this, "portalized", isCommand);
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Portalized.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Portalized.java
@@ -101,11 +101,16 @@ public class Portalized extends Modifier implements Craftable, Listener {
     @EventHandler
     public void onArrowLand(MTProjectileHitEvent e) {
         if (!this.isAllowed()) return;
+
         Player p = e.getPlayer();
+
         LinkedList<ArmorStand> portals = playerPortals.get(p);
+
         if (portals == null) {
             portals = new LinkedList<>();
         }
+
+        if (e.getEvent().getHitBlock() == null) return;
 
         ArmorStand newPortal = (ArmorStand) p.getWorld().spawnEntity(e.getEvent().getHitBlock().getLocation(), EntityType.ARMOR_STAND);
         newPortal.setHelmet(portalHead);
@@ -143,8 +148,8 @@ public class Portalized extends Modifier implements Craftable, Listener {
 
     @EventHandler
     public void onPortalClick(EntityDamageByEntityEvent e) {
-        if (!(e.getDamager() instanceof Player)) return;
-        if (!(e.getEntity() instanceof ArmorStand)) return;
+        //if (!(e.getDamager() instanceof Player)) return;
+        //if (!(e.getEntity() instanceof ArmorStand)) return;
 
         //System.out.println("hi!");
     }

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Portalized.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Portalized.java
@@ -146,12 +146,12 @@ public class Portalized extends Modifier implements Craftable, Listener {
         if (!(e.getDamager() instanceof Player)) return;
         if (!(e.getEntity() instanceof ArmorStand)) return;
 
-        System.out.println("hi!");
+        //System.out.println("hi!");
     }
 
     @EventHandler
     public void PlayerInPortal(AreaEffectCloudApplyEvent e) {
-        System.out.println("hiww");
+        //System.out.println("hiww");
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Portalized.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Portalized.java
@@ -13,6 +13,7 @@ import de.flo56958.MineTinker.Utilities.Modifiers_Config;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -27,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
 
 /**
  * THIS MODIFIER IS FAR FROM FINISHED AND SHOULD NOT BE ENABLED!
@@ -53,6 +55,13 @@ public class Portalized extends Modifier implements Craftable, Listener {
                 new ArrayList<>(Collections.singletonList(ToolType.BOW)),
                 Main.getPlugin());
         Bukkit.getPluginManager().registerEvents(this, Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Power.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Power.java
@@ -18,6 +18,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftPlayer;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -29,6 +30,7 @@ import org.bukkit.inventory.ItemStack;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 
 public class Power extends Modifier implements Enchantable, Craftable, Listener {
 
@@ -48,6 +50,13 @@ public class Power extends Modifier implements Enchantable, Craftable, Listener 
                 new ArrayList<>(Arrays.asList(ToolType.AXE, ToolType.HOE, ToolType.PICKAXE, ToolType.SHOVEL, ToolType.SHEARS)),
                 Main.getPlugin());
         Bukkit.getPluginManager().registerEvents(this, Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Power.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Power.java
@@ -11,7 +11,6 @@ import de.flo56958.MineTinker.Modifiers.Craftable;
 import de.flo56958.MineTinker.Modifiers.Enchantable;
 import de.flo56958.MineTinker.Modifiers.Modifier;
 import de.flo56958.MineTinker.Utilities.*;
-import net.minecraft.server.v1_14_R1.BlockPosition;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -23,6 +22,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 
@@ -275,7 +275,11 @@ public class Power extends Modifier implements Enchantable, Craftable, Listener 
                 && !b.getType().equals(Material.WATER) && !b.getType().equals(Material.BUBBLE_COLUMN) && !b.getType().equals(Material.LAVA)
                 && !b.getType().equals(Material.END_PORTAL) && !b.getType().equals(Material.END_CRYSTAL) && !b.getType().equals(Material.END_PORTAL_FRAME)
                 && !b.getType().equals(Material.NETHER_PORTAL)) {
-            p.getHandle().playerInteractManager.breakBlock(new BlockPosition(b.getX(), b.getY(), b.getZ()));
+
+            BlockBreakEvent event = new BlockBreakEvent(b, p);
+            Bukkit.getServer().getPluginManager().callEvent(event);
+
+            if (!event.isCancelled()) b.breakNaturally(p.getInventory().getItemInMainHand());
         }
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Power.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Power.java
@@ -108,12 +108,12 @@ public class Power extends Modifier implements Enchantable, Craftable, Listener 
      */
     @EventHandler
     public void effect(MTBlockBreakEvent event) {
-        if (event.isCancelled() || !this.isAllowed()) { return; }
+        if (event.isCancelled() || !this.isAllowed()) return;
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
         Block b = event.getBlock();
-        if (!checkPower(p, tool)) { return; }
-        if (ToolType.HOE.getMaterials().contains(tool.getType())) { return; }
+        if (!checkPower(p, tool)) return;
+        if (ToolType.HOE.getMaterials().contains(tool.getType())) return;
 
         ChatWriter.log(false, p.getDisplayName() + " triggered Power on " + ItemGenerator.getDisplayName(tool) + ChatColor.GRAY + " (" + tool.getType().toString() + ")!");
 
@@ -204,15 +204,15 @@ public class Power extends Modifier implements Enchantable, Craftable, Listener 
      */
     @EventHandler
     public void effect(MTPlayerInteractEvent event) {
-        if (!event.isCancelled() || !this.isAllowed()) { return; }
+        if (!event.isCancelled() || !this.isAllowed()) return;
 
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
 
-        if (!ToolType.HOE.getMaterials().contains(tool.getType())) { return; }
+        if (!ToolType.HOE.getMaterials().contains(tool.getType())) return;
 
         PlayerInteractEvent e = event.getEvent();
-        if (!checkPower(p, tool)) { return; }
+        if (!checkPower(p, tool)) return;
 
         ChatWriter.log(false, p.getDisplayName() + " triggered Power on " + ItemGenerator.getDisplayName(tool) + ChatColor.GRAY + " (" + tool.getType().toString() + ")!");
 
@@ -222,14 +222,16 @@ public class Power extends Modifier implements Enchantable, Craftable, Listener 
 
         Block b = e.getClickedBlock();
 
+        if (b == null) return;
+
         if (level == 1) {
             if (Lists.BLOCKFACE.get(p).equals(BlockFace.DOWN) || Lists.BLOCKFACE.get(p).equals(BlockFace.UP)) {
                 Block b1;
                 Block b2;
                 
-                FileConfiguration config = getConfig();
+                //FileConfiguration config = getConfig();
                 
-                if (PlayerInfo.getFacingDirection(p).equals("N") || PlayerInfo.getFacingDirection(p).equals("S")) {
+                if ((PlayerInfo.getFacingDirection(p).equals("N") || PlayerInfo.getFacingDirection(p).equals("S"))) {
                     if (this.lv1_vertical) {
                         b1 = b.getWorld().getBlockAt(b.getLocation().add(0, 0, 1));
                         b2 = b.getWorld().getBlockAt(b.getLocation().add(0, 0, -1));
@@ -290,7 +292,7 @@ public class Power extends Modifier implements Enchantable, Craftable, Listener 
 
     @Override
     public void enchantItem(Player p, ItemStack item) {
-        if (!p.hasPermission("minetinker.modifiers.power.craft")) { return; }
+        if (!p.hasPermission("minetinker.modifiers.power.craft")) return;
         _createModifierItem(getConfig(), p, this, "Power");
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Power.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Power.java
@@ -109,9 +109,11 @@ public class Power extends Modifier implements Enchantable, Craftable, Listener 
     @EventHandler
     public void effect(MTBlockBreakEvent event) {
         if (event.isCancelled() || !this.isAllowed()) return;
+
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
         Block b = event.getBlock();
+
         if (!checkPower(p, tool)) return;
         if (ToolType.HOE.getMaterials().contains(tool.getType())) return;
 
@@ -166,6 +168,7 @@ public class Power extends Modifier implements Enchantable, Craftable, Listener 
             }
         } else {
             HASPOWER.replace(p, true);
+
             if (Lists.BLOCKFACE.get(p).equals(BlockFace.DOWN) || Lists.BLOCKFACE.get(p).equals(BlockFace.UP)) {
                 for (int x = -(level - 1); x <= (level - 1); x++) {
                     for (int z = -(level - 1); z <= (level - 1); z++) {
@@ -219,7 +222,6 @@ public class Power extends Modifier implements Enchantable, Craftable, Listener 
         HASPOWER.replace(p, true);
 
         int level = modManager.getModLevel(tool, this);
-
         Block b = e.getClickedBlock();
 
         if (b == null) return;
@@ -228,9 +230,7 @@ public class Power extends Modifier implements Enchantable, Craftable, Listener 
             if (Lists.BLOCKFACE.get(p).equals(BlockFace.DOWN) || Lists.BLOCKFACE.get(p).equals(BlockFace.UP)) {
                 Block b1;
                 Block b2;
-                
-                //FileConfiguration config = getConfig();
-                
+
                 if ((PlayerInfo.getFacingDirection(p).equals("N") || PlayerInfo.getFacingDirection(p).equals("S"))) {
                     if (this.lv1_vertical) {
                         b1 = b.getWorld().getBlockAt(b.getLocation().add(0, 0, 1));
@@ -251,6 +251,7 @@ public class Power extends Modifier implements Enchantable, Craftable, Listener 
                     b1 = b;
                     b2 = b;
                 }
+
                 powerCreateFarmland(p, tool, b1);
                 powerCreateFarmland(p, tool, b2);
             }
@@ -288,7 +289,9 @@ public class Power extends Modifier implements Enchantable, Craftable, Listener 
         if (b.getType().equals(Material.GRASS_BLOCK) || b.getType().equals(Material.DIRT)) {
             if (b.getWorld().getBlockAt(b.getLocation().add(0, 1, 0)).getType().equals(Material.AIR)) {
                 tool.setDurability((short) (tool.getDurability() + 1));
+
                 Bukkit.getPluginManager().callEvent(new PlayerInteractEvent(p, Action.RIGHT_CLICK_BLOCK, tool, b, BlockFace.UP));
+
                 b.setType(Material.FARMLAND); //Event only does Plugin event (no vanilla conversion to Farmland and Tool-Damage)
             }
         }

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Propelling.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Propelling.java
@@ -136,34 +136,34 @@ public class Propelling extends Modifier implements Craftable, Enchantable, List
 
         if (e.isSneaking()) return;
         if (!p.isGliding()) return;
-
         if (!p.hasPermission("minetinker.modifiers.propelling.use")) return;
+
         ItemStack elytra = p.getInventory().getChestplate();
+
         if (!(modManager.isArmorViable(elytra) && ToolType.ELYTRA.getMaterials().contains(elytra.getType()))) return;
         if (!modManager.hasMod(elytra, this)) return;
 
         int maxDamage = elytra.getType().getMaxDurability();
-
         ItemMeta meta = elytra.getItemMeta();
 
-        // TODO: Make safe
-        Damageable dam = (Damageable) meta;
+        if (meta instanceof Damageable) {
+            Damageable dam = (Damageable) meta;
 
-        if (maxDamage <= dam.getDamage() + durabilityLoss + 1) {
-            p.playSound(p.getLocation(), Sound.ENTITY_ITEM_BREAK, 0.5F, 0.5F);
-            return;
+            if (maxDamage <= dam.getDamage() + durabilityLoss + 1) {
+                p.playSound(p.getLocation(), Sound.ENTITY_ITEM_BREAK, 0.5F, 0.5F);
+                return;
+            }
+
+            dam.setDamage(dam.getDamage() + durabilityLoss);
+            elytra.setItemMeta(meta);
         }
 
-        dam.setDamage(dam.getDamage() + durabilityLoss);
-        elytra.setItemMeta(meta);
-
         int level = modManager.getModLevel(elytra, this);
-
         Location loc = p.getLocation();
-
         Vector dir = loc.getDirection().normalize();
 
         p.setVelocity(p.getVelocity().add(dir.multiply(1 + speedPerLevel * level)));
+
         if (sound && loc.getWorld() != null) loc.getWorld().spawnParticle(Particle.CLOUD, loc, 30, 0.5F, 0.5F, 0.5F, 0.0F);
         if (particles) p.playSound(loc, Sound.ENTITY_ENDER_DRAGON_FLAP, 0.5F, 0.5F);
     }

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Propelling.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Propelling.java
@@ -86,7 +86,7 @@ public class Propelling extends Modifier implements Craftable, Enchantable, List
 
     @Override
     public void enchantItem(Player p, ItemStack item) {
-        if (!p.hasPermission("minetinker.modifiers.propelling.craft")) { return; }
+        if (!p.hasPermission("minetinker.modifiers.propelling.craft")) return;
         _createModifierItem(getConfig(), p, this, "Propelling");
     }
 
@@ -103,17 +103,19 @@ public class Propelling extends Modifier implements Craftable, Enchantable, List
 
         ItemMeta meta = tool.getItemMeta();
 
-        if (ToolType.TRIDENT.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.RIPTIDE, modManager.getModLevel(tool, this), true);
-        } //Elytra does not get an enchantment
+        if (meta != null) {
+            if (ToolType.TRIDENT.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.RIPTIDE, modManager.getModLevel(tool, this), true);
+            } //Elytra does not get an enchantment
 
-        if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
-            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-        } else {
-            meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+            if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            } else {
+                meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+            }
+
+            tool.setItemMeta(meta);
         }
-
-        tool.setItemMeta(meta);
 
         return tool;
     }
@@ -121,25 +123,30 @@ public class Propelling extends Modifier implements Craftable, Enchantable, List
     @Override
     public void removeMod(ItemStack tool) {
         ItemMeta meta = tool.getItemMeta();
-        meta.removeEnchant(Enchantment.RIPTIDE);
-        tool.setItemMeta(meta);
+
+        if (meta != null) {
+            meta.removeEnchant(Enchantment.RIPTIDE);
+            tool.setItemMeta(meta);
+        }
     }
 
     @EventHandler
     public void onElytraSneak(PlayerToggleSneakEvent e) {
         Player p = e.getPlayer();
-        if (e.isCancelled()) { return; }
-        if (e.isSneaking()) { return; }
-        if (!p.isGliding()) { return; }
+        if (e.isCancelled()) return;
+        if (e.isSneaking()) return;
+        if (!p.isGliding()) return;
 
-        if (!p.hasPermission("minetinker.modifiers.propelling.use")) { return; }
+        if (!p.hasPermission("minetinker.modifiers.propelling.use")) return;
         ItemStack elytra = p.getInventory().getChestplate();
-        if (!(modManager.isArmorViable(elytra) && ToolType.ELYTRA.getMaterials().contains(elytra.getType()))) { return; }
-        if (!modManager.hasMod(elytra, this)) { return; }
+        if (!(modManager.isArmorViable(elytra) && ToolType.ELYTRA.getMaterials().contains(elytra.getType()))) return;
+        if (!modManager.hasMod(elytra, this)) return;
 
         int maxDamage = elytra.getType().getMaxDurability();
 
         ItemMeta meta = elytra.getItemMeta();
+
+        // TODO: Make safe
         Damageable dam = (Damageable) meta;
 
         if (maxDamage <= dam.getDamage() + durabilityLoss + 1) {
@@ -157,7 +164,7 @@ public class Propelling extends Modifier implements Craftable, Enchantable, List
         Vector dir = loc.getDirection().normalize();
 
         p.setVelocity(p.getVelocity().add(dir.multiply(1 + speedPerLevel * level)));
-        if (sound) loc.getWorld().spawnParticle(Particle.CLOUD, loc, 30, 0.5F, 0.5F, 0.5F, 0.0F);
+        if (sound && loc.getWorld() != null) loc.getWorld().spawnParticle(Particle.CLOUD, loc, 30, 0.5F, 0.5F, 0.5F, 0.0F);
         if (particles) p.playSound(loc, Sound.ENTITY_ENDER_DRAGON_FLAP, 0.5F, 0.5F);
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Propelling.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Propelling.java
@@ -130,10 +130,10 @@ public class Propelling extends Modifier implements Craftable, Enchantable, List
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onElytraSneak(PlayerToggleSneakEvent e) {
         Player p = e.getPlayer();
-        if (e.isCancelled()) return;
+
         if (e.isSneaking()) return;
         if (!p.isGliding()) return;
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Propelling.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Propelling.java
@@ -25,6 +25,7 @@ import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class Propelling extends Modifier implements Craftable, Enchantable, Listener {
 
@@ -46,6 +47,14 @@ public class Propelling extends Modifier implements Craftable, Enchantable, List
                 new ArrayList<>(Arrays.asList(ToolType.ELYTRA, ToolType.TRIDENT)),
                 Main.getPlugin());
         Bukkit.getPluginManager().registerEvents(this, Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+        enchantments.add(Enchantment.RIPTIDE);
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Protecting.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Protecting.java
@@ -17,6 +17,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class Protecting extends Modifier implements Craftable {
 
@@ -31,6 +32,14 @@ public class Protecting extends Modifier implements Craftable {
         super(ModifierType.PROTECTING,
                 new ArrayList<>(Arrays.asList(ToolType.HELMET, ToolType.CHESTPLATE, ToolType.LEGGINGS, ToolType.BOOTS, ToolType.ELYTRA)),
                 Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+        enchantments.add(Enchantment.PROTECTION_ENVIRONMENTAL);
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Protecting.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Protecting.java
@@ -74,6 +74,7 @@ public class Protecting extends Modifier implements Craftable {
 
         if (meta != null) {
             meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, modManager.getModLevel(tool, this), true);
+
             if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
                 meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             } else {

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Protecting.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Protecting.java
@@ -72,14 +72,16 @@ public class Protecting extends Modifier implements Craftable {
 
         ItemMeta meta = tool.getItemMeta();
 
-        meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, modManager.getModLevel(tool, this), true);
-        if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
-            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-        } else {
-            meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
-        }
+        if (meta != null) {
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, modManager.getModLevel(tool, this), true);
+            if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            } else {
+                meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+            }
 
-        tool.setItemMeta(meta);
+            tool.setItemMeta(meta);
+        }
 
         return tool;
     }
@@ -87,8 +89,11 @@ public class Protecting extends Modifier implements Craftable {
     @Override
     public void removeMod(ItemStack tool) {
         ItemMeta meta = tool.getItemMeta();
-        meta.removeEnchant(Enchantment.PROTECTION_ENVIRONMENTAL);
-        tool.setItemMeta(meta);
+
+        if (meta != null) {
+            meta.removeEnchant(Enchantment.PROTECTION_ENVIRONMENTAL);
+            tool.setItemMeta(meta);
+        }
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Reinforced.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Reinforced.java
@@ -17,6 +17,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class Reinforced extends Modifier implements Craftable {
 
@@ -32,6 +33,14 @@ public class Reinforced extends Modifier implements Craftable {
                 new ArrayList<>(Arrays.asList(ToolType.AXE, ToolType.BOW, ToolType.HOE, ToolType.PICKAXE, ToolType.SHEARS, ToolType.SHOVEL, ToolType.SWORD, ToolType.TRIDENT, ToolType.FISHINGROD,
                                                 ToolType.HELMET, ToolType.CHESTPLATE, ToolType.LEGGINGS, ToolType.BOOTS, ToolType.ELYTRA)),
                 Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+        enchantments.add(Enchantment.DURABILITY);
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Reinforced.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Reinforced.java
@@ -73,6 +73,7 @@ public class Reinforced extends Modifier implements Craftable {
 
         if (meta != null) {
             meta.addEnchant(Enchantment.DURABILITY, modManager.getModLevel(tool, this), true);
+
             if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
                 meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             } else {

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Reinforced.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Reinforced.java
@@ -71,14 +71,16 @@ public class Reinforced extends Modifier implements Craftable {
 
         ItemMeta meta = tool.getItemMeta();
 
-        meta.addEnchant(Enchantment.DURABILITY, modManager.getModLevel(tool, this), true);
-        if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
-            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-        } else {
-            meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
-        }
+        if (meta != null) {
+            meta.addEnchant(Enchantment.DURABILITY, modManager.getModLevel(tool, this), true);
+            if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            } else {
+                meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+            }
 
-        tool.setItemMeta(meta);
+            tool.setItemMeta(meta);
+        }
 
         return tool;
     }
@@ -86,8 +88,11 @@ public class Reinforced extends Modifier implements Craftable {
     @Override
     public void removeMod(ItemStack tool) {
         ItemMeta meta = tool.getItemMeta();
-        meta.removeEnchant(Enchantment.DURABILITY);
-        tool.setItemMeta(meta);
+
+        if (meta != null) {
+            meta.removeEnchant(Enchantment.DURABILITY);
+            tool.setItemMeta(meta);
+        }
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/SelfRepair.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/SelfRepair.java
@@ -28,6 +28,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 public class SelfRepair extends Modifier implements Enchantable, Craftable, Listener {
@@ -51,6 +52,14 @@ public class SelfRepair extends Modifier implements Enchantable, Craftable, List
                                                 ToolType.HELMET, ToolType.CHESTPLATE, ToolType.LEGGINGS, ToolType.BOOTS, ToolType.ELYTRA)),
                 Main.getPlugin());
         Bukkit.getPluginManager().registerEvents(this, Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+        enchantments.add(Enchantment.MENDING);
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/SelfRepair.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/SelfRepair.java
@@ -91,11 +91,13 @@ public class SelfRepair extends Modifier implements Enchantable, Craftable, List
         if (Modifier.checkAndAdd(p, tool, this, "selfrepair", isCommand) == null) {
             return null;
         }
+
         if (useMending) {
             ItemMeta meta = tool.getItemMeta();
 
             if (meta != null) {
                 meta.addEnchant(Enchantment.MENDING, modManager.getModLevel(tool, this), true);
+
                 if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
                     meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
                 } else {
@@ -129,10 +131,12 @@ public class SelfRepair extends Modifier implements Enchantable, Craftable, List
     @EventHandler
     public void effect(MTEntityDamageByEntityEvent event) {
         if (event.isCancelled() || !this.isAllowed()) return;
+
         if (ToolType.BOOTS.getMaterials().contains(event.getTool().getType())
                 || ToolType.LEGGINGS.getMaterials().contains(event.getTool().getType())
                 || ToolType.CHESTPLATE.getMaterials().contains(event.getTool().getType())
                 || ToolType.HELMET.getMaterials().contains(event.getTool().getType())) return; //Makes sure that armor does not get the double effect as it also gets the effect in EntityDamageEvent
+
         effect(event.getPlayer(), event.getTool());
     }
 
@@ -151,8 +155,11 @@ public class SelfRepair extends Modifier implements Enchantable, Craftable, List
     @EventHandler
     public void onShear(PlayerShearEntityEvent event) {
         if (event.isCancelled() || !this.isAllowed()) return;
+
         ItemStack tool = event.getPlayer().getInventory().getItemInMainHand();
+
         if (!(modManager.isToolViable(tool) && ToolType.SHEARS.getMaterials().contains(tool.getType()))) return;
+
         effect(event.getPlayer(), tool);
     }
 
@@ -173,9 +180,9 @@ public class SelfRepair extends Modifier implements Enchantable, Craftable, List
         if (!modManager.hasMod(tool, this)) return;
 
         int level = modManager.getModLevel(tool, this);
-
         Random rand = new Random();
         int n = rand.nextInt(100);
+
         if (n <= this.percentagePerLevel * level) {
             short dura = (short) (tool.getDurability() - this.healthRepair);
 
@@ -184,6 +191,7 @@ public class SelfRepair extends Modifier implements Enchantable, Craftable, List
             }
 
             tool.setDurability(dura);
+
             ChatWriter.log(false, p.getDisplayName() + " triggered Self-Repair on " + ItemGenerator.getDisplayName(tool) + ChatColor.GRAY + " (" + tool.getType().toString() + ")!");
         }
     }

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/SelfRepair.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/SelfRepair.java
@@ -93,14 +93,17 @@ public class SelfRepair extends Modifier implements Enchantable, Craftable, List
         }
         if (useMending) {
             ItemMeta meta = tool.getItemMeta();
-            meta.addEnchant(Enchantment.MENDING, modManager.getModLevel(tool, this), true);
-            if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
-                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-            } else {
-                meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
-            }
 
-            tool.setItemMeta(meta);
+            if (meta != null) {
+                meta.addEnchant(Enchantment.MENDING, modManager.getModLevel(tool, this), true);
+                if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
+                    meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+                } else {
+                    meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+                }
+
+                tool.setItemMeta(meta);
+            }
         }
         return tool;
     }
@@ -108,15 +111,18 @@ public class SelfRepair extends Modifier implements Enchantable, Craftable, List
     @Override
     public void removeMod(ItemStack tool) {
         ItemMeta meta = tool.getItemMeta();
-        meta.removeEnchant(Enchantment.MENDING);
-        tool.setItemMeta(meta);
+
+        if (meta != null) {
+            meta.removeEnchant(Enchantment.MENDING);
+            tool.setItemMeta(meta);
+        }
     }
 
     //------------------------------------------------------
 
     @EventHandler
     public void effect(MTBlockBreakEvent event) {
-        if (event.isCancelled() || !this.isAllowed()) { return; }
+        if (event.isCancelled() || !this.isAllowed()) return;
         effect(event.getPlayer(), event.getTool());
     }
 
@@ -162,9 +168,9 @@ public class SelfRepair extends Modifier implements Enchantable, Craftable, List
      */
     @SuppressWarnings("deprecation")
 	private void effect(Player p, ItemStack tool) {
-        if (useMending) { return; }
-        if (!p.hasPermission("minetinker.modifiers.selfrepair.use")) { return; }
-        if (!modManager.hasMod(tool, this)) { return; }
+        if (useMending) return;
+        if (!p.hasPermission("minetinker.modifiers.selfrepair.use")) return;
+        if (!modManager.hasMod(tool, this)) return;
 
         int level = modManager.getModLevel(tool, this);
 
@@ -186,7 +192,7 @@ public class SelfRepair extends Modifier implements Enchantable, Craftable, List
 
     @Override
     public void enchantItem(Player p, ItemStack item) {
-        if (!p.hasPermission("minetinker.modifiers.selfrepair.craft")) { return; }
+        if (!p.hasPermission("minetinker.modifiers.selfrepair.craft")) return;
         _createModifierItem(getConfig(), p, this, "Self-Repair");
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Sharpness.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Sharpness.java
@@ -81,6 +81,7 @@ public class Sharpness extends Modifier implements Craftable {
                 meta.addEnchant(Enchantment.DAMAGE_ALL, modManager.getModLevel(tool, this), true);
                 meta.addEnchant(Enchantment.IMPALING, modManager.getModLevel(tool, this), true);
             }
+
             if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
                 meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             } else {

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Sharpness.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Sharpness.java
@@ -17,6 +17,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class Sharpness extends Modifier implements Craftable {
 
@@ -31,6 +32,16 @@ public class Sharpness extends Modifier implements Craftable {
         super(ModifierType.SHARPNESS,
                 new ArrayList<>(Arrays.asList(ToolType.AXE, ToolType.BOW, ToolType.SWORD, ToolType.TRIDENT)),
                 Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+        enchantments.add(Enchantment.DAMAGE_ALL);
+        enchantments.add(Enchantment.ARROW_DAMAGE);
+        enchantments.add(Enchantment.IMPALING);
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Sharpness.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Sharpness.java
@@ -70,23 +70,25 @@ public class Sharpness extends Modifier implements Craftable {
 
         ItemMeta meta = tool.getItemMeta();
 
-        if (ToolType.AXE.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.DAMAGE_ALL, modManager.getModLevel(tool, this), true);
-        } else if (ToolType.BOW.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.ARROW_DAMAGE, modManager.getModLevel(tool, this), true);
-        } else if (ToolType.SWORD.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.DAMAGE_ALL, modManager.getModLevel(tool, this), true);
-        } else if (ToolType.TRIDENT.getMaterials().contains(tool.getType())) {
-            meta.addEnchant(Enchantment.DAMAGE_ALL, modManager.getModLevel(tool, this), true);
-            meta.addEnchant(Enchantment.IMPALING, modManager.getModLevel(tool, this), true);
-        }
-        if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
-            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-        } else {
-            meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
-        }
+        if (meta != null) {
+            if (ToolType.AXE.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.DAMAGE_ALL, modManager.getModLevel(tool, this), true);
+            } else if (ToolType.BOW.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.ARROW_DAMAGE, modManager.getModLevel(tool, this), true);
+            } else if (ToolType.SWORD.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.DAMAGE_ALL, modManager.getModLevel(tool, this), true);
+            } else if (ToolType.TRIDENT.getMaterials().contains(tool.getType())) {
+                meta.addEnchant(Enchantment.DAMAGE_ALL, modManager.getModLevel(tool, this), true);
+                meta.addEnchant(Enchantment.IMPALING, modManager.getModLevel(tool, this), true);
+            }
+            if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            } else {
+                meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+            }
 
-        tool.setItemMeta(meta);
+            tool.setItemMeta(meta);
+        }
 
         return tool;
     }
@@ -94,10 +96,14 @@ public class Sharpness extends Modifier implements Craftable {
     @Override
     public void removeMod(ItemStack tool) {
         ItemMeta meta = tool.getItemMeta();
-        meta.removeEnchant(Enchantment.DAMAGE_ALL);
-        meta.removeEnchant(Enchantment.ARROW_DAMAGE);
-        meta.removeEnchant(Enchantment.IMPALING);
-        tool.setItemMeta(meta);
+
+        if (meta != null) {
+            meta.removeEnchant(Enchantment.DAMAGE_ALL);
+            meta.removeEnchant(Enchantment.ARROW_DAMAGE);
+            meta.removeEnchant(Enchantment.IMPALING);
+
+            tool.setItemMeta(meta);
+        }
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Shulking.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Shulking.java
@@ -121,6 +121,7 @@ public class Shulking extends Modifier implements Craftable, Listener {
         int amplifier = this.effectAmplifier * (level - 1);
 
         ((LivingEntity) ent).addPotionEffect(new PotionEffect(PotionEffectType.LEVITATION, this.duration, amplifier, false, false));
+
         ChatWriter.log(false, p.getDisplayName() + " triggered Shulking on " + ItemGenerator.getDisplayName(tool) + ChatColor.GRAY + " (" + tool.getType().toString() + ")!");
 
     }

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Shulking.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Shulking.java
@@ -14,6 +14,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -25,6 +26,7 @@ import org.bukkit.potion.PotionEffectType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class Shulking extends Modifier implements Craftable, Listener {
 
@@ -44,6 +46,13 @@ public class Shulking extends Modifier implements Craftable, Listener {
                                                 ToolType.HELMET, ToolType.CHESTPLATE, ToolType.LEGGINGS, ToolType.BOOTS, ToolType.ELYTRA)),
                 Main.getPlugin());
         Bukkit.getPluginManager().registerEvents(this, Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Shulking.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Shulking.java
@@ -91,8 +91,8 @@ public class Shulking extends Modifier implements Craftable, Listener {
 
     @EventHandler
     public void effect(MTEntityDamageByEntityEvent event) {
-        if (event.isCancelled() || !this.isAllowed()) { return; }
-        if (!(event.getEntity() instanceof LivingEntity)) { return; }
+        if (event.isCancelled() || !this.isAllowed()) return;
+        if (!(event.getEntity() instanceof LivingEntity)) return;
 
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
@@ -102,20 +102,20 @@ public class Shulking extends Modifier implements Craftable, Listener {
 
     @EventHandler
     public void effect(MTProjectileHitEvent event) {
-        if (!this.isAllowed()) { return; }
-        if (!(event.getEvent().getHitEntity() instanceof LivingEntity)) { return; }
+        if (!this.isAllowed()) return;
+        if (!(event.getEvent().getHitEntity() instanceof LivingEntity)) return;
 
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
 
-        if (!ToolType.FISHINGROD.getMaterials().contains(tool.getType())) { return; }
+        if (!ToolType.FISHINGROD.getMaterials().contains(tool.getType())) return;
 
         effect(p, tool, event.getEvent().getHitEntity());
     }
 
     private void effect(Player p, ItemStack tool, Entity ent) {
-        if (!p.hasPermission("minetinker.modifiers.shulking.use")) { return; }
-        if (!modManager.hasMod(tool, this)) { return; }
+        if (!p.hasPermission("minetinker.modifiers.shulking.use")) return;
+        if (!modManager.hasMod(tool, this)) return;
 
         int level = modManager.getModLevel(tool, this);
         int amplifier = this.effectAmplifier * (level - 1);

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/SilkTouch.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/SilkTouch.java
@@ -83,14 +83,16 @@ public class SilkTouch extends Modifier implements Enchantable, Craftable {
 
         ItemMeta meta = tool.getItemMeta();
 
-        meta.addEnchant(Enchantment.SILK_TOUCH, modManager.getModLevel(tool, this), true);
-        if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
-            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-        } else {
-            meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
-        }
+        if (meta != null) {
+            meta.addEnchant(Enchantment.SILK_TOUCH, modManager.getModLevel(tool, this), true);
+            if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            } else {
+                meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+            }
 
-        tool.setItemMeta(meta);
+            tool.setItemMeta(meta);
+        }
 
         return tool;
     }
@@ -98,13 +100,16 @@ public class SilkTouch extends Modifier implements Enchantable, Craftable {
     @Override
     public void removeMod(ItemStack tool) {
         ItemMeta meta = tool.getItemMeta();
-        meta.removeEnchant(Enchantment.SILK_TOUCH);
-        tool.setItemMeta(meta);
+
+        if (meta != null) {
+            meta.removeEnchant(Enchantment.SILK_TOUCH);
+            tool.setItemMeta(meta);
+        }
     }
 
     @Override
     public void enchantItem(Player p, ItemStack item) {
-        if (!p.hasPermission("minetinker.modifiers.silktouch.craft")) { return; }
+        if (!p.hasPermission("minetinker.modifiers.silktouch.craft")) return;
         _createModifierItem(getConfig(), p, this, "Silk-Touch");
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/SilkTouch.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/SilkTouch.java
@@ -20,6 +20,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class SilkTouch extends Modifier implements Enchantable, Craftable {
 
@@ -34,6 +35,14 @@ public class SilkTouch extends Modifier implements Enchantable, Craftable {
         super(ModifierType.SILK_TOUCH,
                 new ArrayList<>(Arrays.asList(ToolType.AXE, ToolType.HOE, ToolType.PICKAXE, ToolType.SHOVEL, ToolType.SHEARS)),
                 Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+        enchantments.add(Enchantment.SILK_TOUCH);
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/SilkTouch.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/SilkTouch.java
@@ -71,12 +71,14 @@ public class SilkTouch extends Modifier implements Enchantable, Craftable {
                 return null;
             }
         }
+
         if (modManager.get(ModifierType.LUCK) != null) {
             if (modManager.hasMod(tool, modManager.get(ModifierType.LUCK))) {
                 pluginManager.callEvent(new ModifierFailEvent(p, tool, this, ModifierFailCause.INCOMPATIBLE_MODIFIERS, isCommand));
                 return null;
             }
         }
+
         if (Modifier.checkAndAdd(p, tool, this, "silktouch", isCommand) == null) {
             return null;
         }

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Soulbound.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Soulbound.java
@@ -13,6 +13,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -24,6 +25,7 @@ import org.bukkit.inventory.ItemStack;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Random;
 
 public class Soulbound extends Modifier implements Craftable, Listener {
@@ -47,6 +49,13 @@ public class Soulbound extends Modifier implements Craftable, Listener {
                                                 ToolType.HELMET, ToolType.CHESTPLATE, ToolType.LEGGINGS, ToolType.BOOTS, ToolType.ELYTRA)),
                 Main.getPlugin());
         Bukkit.getPluginManager().registerEvents(this, Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Soulbound.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Soulbound.java
@@ -159,10 +159,8 @@ public class Soulbound extends Modifier implements Craftable, Listener {
      * Effect if a player drops an item
      * @param e
      */
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void effect(PlayerDropItemEvent e) {
-        if (e.isCancelled()) return;
-
         Item item = e.getItemDrop();
         ItemStack is = item.getItemStack();
         if (!(modManager.isArmorViable(is) || modManager.isToolViable(is) || modManager.isWandViable(is))) return;

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Soulbound.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Soulbound.java
@@ -141,9 +141,9 @@ public class Soulbound extends Modifier implements Craftable, Listener {
     @EventHandler
     public void effect(PlayerRespawnEvent e) {
         Player p = e.getPlayer();
-        if (!p.hasPermission("minetinker.modifiers.soulbound.use")) { return; }
+        if (!p.hasPermission("minetinker.modifiers.soulbound.use")) return;
 
-        if (!storedItemStacks.containsKey(p)) { return; }
+        if (!storedItemStacks.containsKey(p)) return;
 
         ArrayList<ItemStack> stored = storedItemStacks.get(p);
         for (ItemStack is : stored) {
@@ -161,14 +161,14 @@ public class Soulbound extends Modifier implements Craftable, Listener {
      */
     @EventHandler
     public void effect(PlayerDropItemEvent e) {
-        if (e.isCancelled()) { return; }
+        if (e.isCancelled()) return;
 
         Item item = e.getItemDrop();
         ItemStack is = item.getItemStack();
-        if (!(modManager.isArmorViable(is) || modManager.isToolViable(is) || modManager.isWandViable(is))) { return; }
+        if (!(modManager.isArmorViable(is) || modManager.isToolViable(is) || modManager.isWandViable(is))) return;
 
-        if (!modManager.hasMod(is, this)) { return; }
-        if (toolDropable) { return; }
+        if (!modManager.hasMod(is, this)) return;
+        if (toolDropable) return;
 
         e.setCancelled(true);
     }

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Soulbound.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Soulbound.java
@@ -141,11 +141,12 @@ public class Soulbound extends Modifier implements Craftable, Listener {
     @EventHandler
     public void effect(PlayerRespawnEvent e) {
         Player p = e.getPlayer();
-        if (!p.hasPermission("minetinker.modifiers.soulbound.use")) return;
 
+        if (!p.hasPermission("minetinker.modifiers.soulbound.use")) return;
         if (!storedItemStacks.containsKey(p)) return;
 
         ArrayList<ItemStack> stored = storedItemStacks.get(p);
+
         for (ItemStack is : stored) {
             if (p.getInventory().addItem(is).size() != 0) { //adds items to (full) inventory
                 p.getWorld().dropItem(p.getLocation(), is);
@@ -163,8 +164,8 @@ public class Soulbound extends Modifier implements Craftable, Listener {
     public void effect(PlayerDropItemEvent e) {
         Item item = e.getItemDrop();
         ItemStack is = item.getItemStack();
-        if (!(modManager.isArmorViable(is) || modManager.isToolViable(is) || modManager.isWandViable(is))) return;
 
+        if (!(modManager.isArmorViable(is) || modManager.isToolViable(is) || modManager.isWandViable(is))) return;
         if (!modManager.hasMod(is, this)) return;
         if (toolDropable) return;
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Sweeping.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Sweeping.java
@@ -70,14 +70,16 @@ public class Sweeping extends Modifier implements Enchantable, Craftable {
 
         ItemMeta meta = tool.getItemMeta();
 
-        meta.addEnchant(Enchantment.SWEEPING_EDGE, modManager.getModLevel(tool, this), true);
-        if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
-            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-        } else {
-            meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
-        }
+        if (meta != null) {
+            meta.addEnchant(Enchantment.SWEEPING_EDGE, modManager.getModLevel(tool, this), true);
+            if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            } else {
+                meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+            }
 
-        tool.setItemMeta(meta);
+            tool.setItemMeta(meta);
+        }
 
         return tool;
     }
@@ -87,7 +89,7 @@ public class Sweeping extends Modifier implements Enchantable, Craftable {
 
     @Override
     public void enchantItem(Player p, ItemStack item) {
-        if (!p.hasPermission("minetinker.modifiers.sweeping.craft")) { return; }
+        if (!p.hasPermission("minetinker.modifiers.sweeping.craft")) return;
         _createModifierItem(getConfig(), p, this, "Sweeping");
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Sweeping.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Sweeping.java
@@ -18,6 +18,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 public class Sweeping extends Modifier implements Enchantable, Craftable {
 
@@ -34,6 +35,14 @@ public class Sweeping extends Modifier implements Enchantable, Craftable {
         super(ModifierType.SWEEPING,
                 new ArrayList<>(Collections.singletonList(ToolType.SWORD)),
                 Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+        enchantments.add(Enchantment.SWEEPING_EDGE);
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Sweeping.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Sweeping.java
@@ -72,6 +72,7 @@ public class Sweeping extends Modifier implements Enchantable, Craftable {
 
         if (meta != null) {
             meta.addEnchant(Enchantment.SWEEPING_EDGE, modManager.getModLevel(tool, this), true);
+
             if (Main.getPlugin().getConfig().getBoolean("HideEnchants")) {
                 meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             } else {

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Timber.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Timber.java
@@ -12,17 +12,16 @@ import de.flo56958.MineTinker.Utilities.ChatWriter;
 import de.flo56958.MineTinker.Utilities.ConfigurationManager;
 import de.flo56958.MineTinker.Utilities.ItemGenerator;
 import de.flo56958.MineTinker.Utilities.Modifiers_Config;
-import net.minecraft.server.v1_14_R1.BlockPosition;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.craftbukkit.v1_14_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
@@ -152,7 +151,11 @@ public class Timber extends Modifier implements Craftable, Listener {
                     locs.add(loc);
                     if (allowed.contains(p.getWorld().getBlockAt(loc).getType())) {
                         breakTree(p, p.getWorld().getBlockAt(loc), allowed);
-                        ((CraftPlayer) p).getHandle().playerInteractManager.breakBlock(new BlockPosition(loc.getX(), loc.getY(), loc.getZ()));
+
+                        BlockBreakEvent event = new BlockBreakEvent(b, p);
+                        Bukkit.getServer().getPluginManager().callEvent(event);
+
+                        if (!event.isCancelled()) b.breakNaturally(p.getInventory().getItemInMainHand());
                     }
                 }
             }

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Timber.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Timber.java
@@ -93,6 +93,7 @@ public class Timber extends Modifier implements Craftable, Listener {
     @EventHandler
     public void effect(MTBlockBreakEvent event) {
         if (event.isCancelled() || !this.isAllowed()) return;
+
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
         Block b = event.getBlock();
@@ -103,14 +104,17 @@ public class Timber extends Modifier implements Craftable, Listener {
         ArrayList<Material> allowed = new ArrayList<>();
         allowed.addAll(Lists.getWoodLogs());
         allowed.addAll(Lists.getWoodWood());
+
         boolean isTreeBottom = false; //checks for Grass or Dirt under Log
         boolean isTreeTop = false; //checks for Leaves above Log
+
         for (int y = b.getY() - 1; y > 0; y--) {
             if (p.getWorld().getBlockAt(b.getX(), y, b.getZ()).getType().equals(Material.GRASS_BLOCK) //for freshly grown trees
                     || p.getWorld().getBlockAt(b.getX(), y, b.getZ()).getType().equals(Material.DIRT)
                     || p.getWorld().getBlockAt(b.getX(), y, b.getZ()).getType().equals(Material.PODZOL)) { //for the 2x2 spruce trees
                 isTreeBottom = true;
             }
+
             if (!p.getWorld().getBlockAt(b.getX(), y, b.getZ()).getType().equals(b.getType())) {
                 break;
             }
@@ -120,6 +124,7 @@ public class Timber extends Modifier implements Craftable, Listener {
             if (!allowed.contains(p.getWorld().getBlockAt(b.getX(), dy, b.getZ()).getType())) {
                 Location loc = b.getLocation().clone();
                 loc.setY(dy);
+
                 if (Lists.getWoodLeaves().contains(p.getWorld().getBlockAt(loc).getType())) {
                     isTreeTop = true;
                 }
@@ -146,9 +151,13 @@ public class Timber extends Modifier implements Craftable, Listener {
                 for (int dz = -1; dz <= 1; dz++) {
                     Location loc = b.getLocation().clone();
                     loc.add(dx, dy, dz);
+
                     if (locs.contains(loc)) { continue; }
+
                     if (getConfig().getInt("Timber.MaximumBlocksPerSwing") > 0 && locs.size() >= getConfig().getInt("Timber.MaximumBlocksPerSwing")) return;
+
                     locs.add(loc);
+
                     if (allowed.contains(p.getWorld().getBlockAt(loc).getType())) {
                         breakTree(p, p.getWorld().getBlockAt(loc), allowed);
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Timber.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Timber.java
@@ -93,13 +93,13 @@ public class Timber extends Modifier implements Craftable, Listener {
 
     @EventHandler
     public void effect(MTBlockBreakEvent event) {
-        if (event.isCancelled() || !this.isAllowed()) { return; }
+        if (event.isCancelled() || !this.isAllowed()) return;
         Player p = event.getPlayer();
         ItemStack tool = event.getTool();
         Block b = event.getBlock();
 
-        if (Power.HASPOWER.get(p) || p.isSneaking()) { return; }
-        if (!modManager.hasMod(tool, this)) { return; }
+        if (Power.HASPOWER.get(p) || p.isSneaking()) return;
+        if (!modManager.hasMod(tool, this)) return;
 
         ArrayList<Material> allowed = new ArrayList<>();
         allowed.addAll(Lists.getWoodLogs());
@@ -128,7 +128,7 @@ public class Timber extends Modifier implements Craftable, Listener {
             }
         }
 
-        if (!isTreeBottom || !isTreeTop) { return; } //TODO: Improve tree check
+        if (!isTreeBottom || !isTreeTop) return; //TODO: Improve tree check
 
         Power.HASPOWER.replace(p, true);
         locs.add(b.getLocation());
@@ -148,7 +148,7 @@ public class Timber extends Modifier implements Craftable, Listener {
                     Location loc = b.getLocation().clone();
                     loc.add(dx, dy, dz);
                     if (locs.contains(loc)) { continue; }
-                    if (getConfig().getInt("Timber.MaximumBlocksPerSwing") > 0 && locs.size() >= getConfig().getInt("Timber.MaximumBlocksPerSwing")) { return; }
+                    if (getConfig().getInt("Timber.MaximumBlocksPerSwing") > 0 && locs.size() >= getConfig().getInt("Timber.MaximumBlocksPerSwing")) return;
                     locs.add(loc);
                     if (allowed.contains(p.getWorld().getBlockAt(loc).getType())) {
                         breakTree(p, p.getWorld().getBlockAt(loc), allowed);

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Timber.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Timber.java
@@ -18,6 +18,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -26,6 +27,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 public class Timber extends Modifier implements Craftable, Listener {
 
@@ -43,6 +45,13 @@ public class Timber extends Modifier implements Craftable, Listener {
                 new ArrayList<>(Collections.singletonList(ToolType.AXE)),
                 Main.getPlugin());
         Bukkit.getPluginManager().registerEvents(this, Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Webbed.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Webbed.java
@@ -96,6 +96,7 @@ public class Webbed extends Modifier implements Craftable, Listener {
     public void effect(MTEntityDamageByEntityEvent event) {
         if (event.isCancelled() || !this.isAllowed()) return;
         if (!(event.getEntity() instanceof LivingEntity)) return;
+
         effect(event.getPlayer(), event.getTool(), event.getEntity());
     }
 
@@ -119,6 +120,7 @@ public class Webbed extends Modifier implements Craftable, Listener {
         int amplifier = this.effectAmplifier * (level - 1) / 2;
 
         ((LivingEntity) ent).addPotionEffect(new PotionEffect(PotionEffectType.SLOW, duration, amplifier, false, false));
+
         ChatWriter.log(false, p.getDisplayName() + " triggered Webbed on " + ItemGenerator.getDisplayName(tool) + ChatColor.GRAY + " (" + tool.getType().toString() + ")!");
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Webbed.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Webbed.java
@@ -14,6 +14,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -25,6 +26,7 @@ import org.bukkit.potion.PotionEffectType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class Webbed extends Modifier implements Craftable, Listener {
 
@@ -45,6 +47,13 @@ public class Webbed extends Modifier implements Craftable, Listener {
                                                 ToolType.HELMET, ToolType.CHESTPLATE, ToolType.LEGGINGS, ToolType.BOOTS, ToolType.ELYTRA)),
                 Main.getPlugin());
         Bukkit.getPluginManager().registerEvents(this, Main.getPlugin());
+    }
+
+    @Override
+    public List<Enchantment> getAppliedEnchantments() {
+        List<Enchantment> enchantments = new ArrayList<>();
+
+        return enchantments;
     }
 
     @Override

--- a/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Webbed.java
+++ b/src/main/java/de/flo56958/MineTinker/Modifiers/Types/Webbed.java
@@ -94,24 +94,24 @@ public class Webbed extends Modifier implements Craftable, Listener {
 
     @EventHandler
     public void effect(MTEntityDamageByEntityEvent event) {
-        if (event.isCancelled() || !this.isAllowed()) { return; }
-        if (!(event.getEntity() instanceof LivingEntity)) { return; }
+        if (event.isCancelled() || !this.isAllowed()) return;
+        if (!(event.getEntity() instanceof LivingEntity)) return;
         effect(event.getPlayer(), event.getTool(), event.getEntity());
     }
 
     @EventHandler
     public void effect(MTProjectileHitEvent event) {
-        if (!this.isAllowed()) { return; }
-        if (!(event.getEvent().getHitEntity() instanceof LivingEntity)) { return; }
-        if (!ToolType.FISHINGROD.getMaterials().contains(event.getTool().getType())) { return; }
+        if (!this.isAllowed()) return;
+        if (!(event.getEvent().getHitEntity() instanceof LivingEntity)) return;
+        if (!ToolType.FISHINGROD.getMaterials().contains(event.getTool().getType())) return;
 
         effect(event.getPlayer(), event.getTool(), event.getEvent().getHitEntity());
     }
 
     private void effect(Player p, ItemStack tool, Entity ent) {
-        if (!p.hasPermission("minetinker.modifiers.webbed.use")) { return; }
-        if (ent.isDead()) { return; }
-        if (!modManager.hasMod(tool, this)) { return; }
+        if (!p.hasPermission("minetinker.modifiers.webbed.use")) return;
+        if (ent.isDead()) return;
+        if (!modManager.hasMod(tool, this)) return;
 
         int level = modManager.getModLevel(tool, this);
 

--- a/src/main/java/de/flo56958/MineTinker/Utilities/ChatWriter.java
+++ b/src/main/java/de/flo56958/MineTinker/Utilities/ChatWriter.java
@@ -1,14 +1,11 @@
 package de.flo56958.MineTinker.Utilities;
 
 import de.flo56958.MineTinker.Main;
-import net.minecraft.server.v1_14_R1.ChatComponentText;
-import net.minecraft.server.v1_14_R1.ChatMessageType;
-import net.minecraft.server.v1_14_R1.PacketPlayOutChat;
-import net.minecraft.server.v1_14_R1.PlayerConnection;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.craftbukkit.v1_14_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -77,11 +74,7 @@ public class ChatWriter {
     public static void sendActionBar(Player player, String message) { //Extract from the source code of the Actionbar-API (altered)
         if (!Main.getPlugin().getConfig().getBoolean("actionbar-messages")) return;
         if (!player.isOnline()) return; // Player may have logged out
-        CraftPlayer cp = (CraftPlayer) player;
-        ChatComponentText ccT = new ChatComponentText(message);
-        PacketPlayOutChat ppOC = new PacketPlayOutChat(ccT, ChatMessageType.GAME_INFO);
-        PlayerConnection pC = cp.getHandle().playerConnection;
-        pC.sendPacket(ppOC);
+        player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(message));
     }
 
     /**

--- a/src/main/java/de/flo56958/MineTinker/Utilities/ChatWriter.java
+++ b/src/main/java/de/flo56958/MineTinker/Utilities/ChatWriter.java
@@ -75,8 +75,8 @@ public class ChatWriter {
      * @param message
      */
     public static void sendActionBar(Player player, String message) { //Extract from the source code of the Actionbar-API (altered)
-        if (!Main.getPlugin().getConfig().getBoolean("actionbar-messages")) { return; }
-        if (!player.isOnline()) { return; } // Player may have logged out
+        if (!Main.getPlugin().getConfig().getBoolean("actionbar-messages")) return;
+        if (!player.isOnline()) return; // Player may have logged out
         CraftPlayer cp = (CraftPlayer) player;
         ChatComponentText ccT = new ChatComponentText(message);
         PacketPlayOutChat ppOC = new PacketPlayOutChat(ccT, ChatMessageType.GAME_INFO);

--- a/src/main/java/de/flo56958/MineTinker/Utilities/ChatWriter.java
+++ b/src/main/java/de/flo56958/MineTinker/Utilities/ChatWriter.java
@@ -74,6 +74,7 @@ public class ChatWriter {
     public static void sendActionBar(Player player, String message) { //Extract from the source code of the Actionbar-API (altered)
         if (!Main.getPlugin().getConfig().getBoolean("actionbar-messages")) return;
         if (!player.isOnline()) return; // Player may have logged out
+
         player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(message));
     }
 
@@ -99,6 +100,7 @@ public class ChatWriter {
         // Re-sends the messages every 3 seconds so it doesn't go away from the player's screen.
         while (duration > 40) {
             duration -= 40;
+
             new BukkitRunnable() {
                 @Override
                 public void run() {
@@ -195,10 +197,13 @@ public class ChatWriter {
         for (int i = 0; i < romanValues.length; i++) {
             int numberInPlace = num / romanValues[i];
             if (numberInPlace == 0) continue;
+
             result.append(numberInPlace == 4 && i > 0 ? romanCharacters[i] + romanCharacters[i - 1] :
                     new String(new char[numberInPlace]).replace("\0", romanCharacters[i]));
+
             num = num % romanValues[i];
         }
+
         return addColors(result.toString());
     }
 }

--- a/src/main/java/de/flo56958/MineTinker/Utilities/ConfigurationManager.java
+++ b/src/main/java/de/flo56958/MineTinker/Utilities/ConfigurationManager.java
@@ -57,6 +57,7 @@ public class ConfigurationManager {
     public static void loadConfig(String folder, String file) {
         File customConfigFile = new File(Main.getPlugin().getDataFolder(), folder + file);
         YamlConfiguration fileConfiguration = new YamlConfiguration();
+
         configsFolder.put(fileConfiguration, customConfigFile);
         configs.put(file, fileConfiguration);
         

--- a/src/main/java/de/flo56958/MineTinker/Utilities/ConfigurationManager.java
+++ b/src/main/java/de/flo56958/MineTinker/Utilities/ConfigurationManager.java
@@ -60,7 +60,7 @@ public class ConfigurationManager {
         configsFolder.put(fileConfiguration, customConfigFile);
         configs.put(file, fileConfiguration);
         
-        if(customConfigFile.exists()) {
+        if (customConfigFile.exists()) {
         	try {
 	            fileConfiguration.load(customConfigFile);
 	        } catch (IOException | InvalidConfigurationException e) { e.printStackTrace(); }

--- a/src/main/java/de/flo56958/MineTinker/Utilities/ItemGenerator.java
+++ b/src/main/java/de/flo56958/MineTinker/Utilities/ItemGenerator.java
@@ -22,20 +22,29 @@ public class ItemGenerator {
     private static final ModManager modManager = ModManager.instance();
 
     public static String getDisplayName (ItemStack tool) {
-        String name = tool.getItemMeta().getDisplayName();
-        if (tool.getItemMeta().getDisplayName() == null || tool.getItemMeta().getDisplayName().equals("")) {
+        String name ;
+
+        if (tool.getItemMeta() == null || tool.getItemMeta().getDisplayName().equals("")) {
             name = tool.getType().toString();
+        } else {
+            name = tool.getItemMeta().getDisplayName();
         }
+
         return name;
     }
 
     public static ItemStack itemEnchanter(Material m, String name, int amount, Enchantment ench, int level) {
         ItemStack item = new ItemStack(m, amount);
         ItemMeta meta = item.getItemMeta();
-        meta.setDisplayName(name);
-        meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-        item.setItemMeta(meta);
+
+        if (meta != null) {
+            meta.setDisplayName(name);
+            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            item.setItemMeta(meta);
+        }
+
         item.addUnsafeEnchantment(ench, level);
+
         return item;
     }
 
@@ -291,8 +300,12 @@ public class ItemGenerator {
                     return null;
             }
         }
-        Damageable dam = (Damageable) meta;
-        dam.setDamage(0);
+
+        if (meta instanceof Damageable) {
+            Damageable dam = (Damageable) meta;
+            dam.setDamage(0);
+        }
+
         tool.setItemMeta(meta);
         return tool;
     }

--- a/src/main/java/de/flo56958/MineTinker/Utilities/ItemGenerator.java
+++ b/src/main/java/de/flo56958/MineTinker/Utilities/ItemGenerator.java
@@ -2,11 +2,8 @@ package de.flo56958.MineTinker.Utilities;
 
 import de.flo56958.MineTinker.Data.ToolType;
 import de.flo56958.MineTinker.Events.ToolUpgradeEvent;
-import de.flo56958.MineTinker.Main;
-import de.flo56958.MineTinker.Modifiers.ModManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
-import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemFlag;
@@ -18,8 +15,8 @@ import org.bukkit.plugin.PluginManager;
 public class ItemGenerator {
 
     private static final PluginManager pluginManager = Bukkit.getPluginManager();
-    private static final FileConfiguration config = Main.getPlugin().getConfig();
-    private static final ModManager modManager = ModManager.instance();
+    //private static final FileConfiguration config = Main.getPlugin().getConfig();
+    //private static final ModManager modManager = ModManager.instance();
 
     public static String getDisplayName (ItemStack tool) {
         String name ;
@@ -51,6 +48,7 @@ public class ItemGenerator {
 	public static ItemStack itemUpgrader(ItemStack tool, ItemStack upgrade, Player p) {
         ItemMeta meta = tool.getItemMeta();
         String[] name = tool.getType().toString().split("_");
+
         if (name[0].toLowerCase().equals("wooden") && (
                 upgrade.getType().equals(Material.ACACIA_PLANKS) ||
                 upgrade.getType().equals(Material.BIRCH_PLANKS) ||
@@ -58,6 +56,7 @@ public class ItemGenerator {
                 upgrade.getType().equals(Material.JUNGLE_PLANKS) ||
                 upgrade.getType().equals(Material.OAK_PLANKS) ||
                 upgrade.getType().equals(Material.SPRUCE_PLANKS))) {
+
             pluginManager.callEvent(new ToolUpgradeEvent(p, tool, false));
             return null;
         } else if (name[0].toLowerCase().equals("stone") && upgrade.getType().equals(Material.COBBLESTONE)) {
@@ -82,6 +81,7 @@ public class ItemGenerator {
             pluginManager.callEvent(new ToolUpgradeEvent(p, tool, false));
             return null;
         }
+
         if (ToolType.SWORD.getMaterials().contains(tool.getType())) {
             switch (upgrade.getType()) {
                 case ACACIA_PLANKS:

--- a/src/main/java/de/flo56958/MineTinker/Utilities/PlayerInfo.java
+++ b/src/main/java/de/flo56958/MineTinker/Utilities/PlayerInfo.java
@@ -10,9 +10,11 @@ public class PlayerInfo {
      */
     public static String getFacingDirection(Player player) {
         double rot = (player.getLocation().getYaw() - 90) % 360;
+
         if (rot < 0) {
             rot += 360.0;
         }
+
         return getDirection(rot);
     }
 

--- a/src/main/java/de/flo56958/MineTinker/Utilities/Updater.java
+++ b/src/main/java/de/flo56958/MineTinker/Utilities/Updater.java
@@ -35,7 +35,6 @@ public class Updater {
             StringBuilder content;
 
             try (BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()))) {
-
                 String line;
                 content = new StringBuilder();
 
@@ -66,6 +65,7 @@ public class Updater {
         if (!this.hasUpdate) {
             this.onlineVersion = this.checkOnline();
         }
+
         if (this.onlineVersion.equals("")) {
             ChatWriter.logInfo("MineTinker is unable to check for updates.");
             this.hasUpdate = false;
@@ -88,6 +88,7 @@ public class Updater {
         if (!this.hasUpdate) {
             this.onlineVersion = this.checkOnline();
         }
+
         if (this.onlineVersion.equals("")) {
             ChatWriter.sendMessage(sender, ChatColor.RED, "Unable to check for updates!");
             this.hasUpdate = false;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -49,6 +49,8 @@ ItemBehaviour:
   SetInvulnerable: true #Item can not be damaged or destroyed
   SetPersistent: true #Item will not despawn
   ForModItems: true #Settings apply also for Modifier-Items
+  StopBreakEvent: false #If the item breaks due to a bug, give the item back to the player with 1 durability
+  AlertPlayerOnBreak: false #If the item breaks due to a bug, alert the player
 
 #---------------LEVELUP-EVENTS--------------
 LevelUpEvents:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -42,6 +42,7 @@ AllowCrafting: true #Only recommended if used in combination with other Plugins 
 BlockToEnchantModifiers: BOOKSHELF #Block that needs to be right-clicked
 HideEnchants: true #Should the vanilla enchantments be hidden on the tool
 DurabilityPercentageRepair: 0.34 #How much durability (relative to maximum durability) should the tool recover per item
+ConvertBookToModifier: false #Should right clicking a bookshelf with an enchanted book convert enchantments to modifier items
 
 #---------------ITEMBEHAVIOUR--------------
 ItemBehaviour:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,12 +1,13 @@
 #---------------MAIN-PLUGIN-SETTINGS--------------
 chat-prefix: [MineTinker]
 CheckForUpdates: true #Checks for updates on startup
-SendUpdateNotificationToOPs: true #If there is an update the server OP get a notification
+
 #--LOGGING--
 logging:
   standard: false #logs important player activities with MineTinker
   debug: false #even more information
   metrics: true
+
 #--MESSAGES--
 chat-messages: true #Will turn off command output
 actionbar-messages: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -26,6 +26,7 @@ permissions:
       minetinker.builderswands.*: true
       minetinker.tool.*: true
       minetinker.spawners.*: true
+      minetinker.update.*: true
 
   minetinker.tool.*:
     children:
@@ -117,6 +118,14 @@ permissions:
 
   minetinker.commands.reload:
     description: Allows to reload the configuration-files from MineTinker
+    default: op
+
+  minetinker.update.*:
+    children:
+      minetinker.update.notify: true
+
+  minetinker.update.notify:
+    description: Notifies player about updates when they login
     default: op
 
   #Modifiers:


### PR DESCRIPTION
- Added opt-in terracotta -> glazed_terracotta in auto-smelt
- Changed update notifications to use permissions instead of op status
- Removed as much NMS usage as possible (effects EasyHarvest, Timber, Power, ChatWriter)
- Prevent ARROW modifier items from being shot and ensure this doesn't cause ghost items
- Use 1.14.1 instead of 1.14 in maven
- Slight cleanup of a lot of code
- Give MineTinker items back to the player if they manage to break
- Prevent modifier items like ender pearls from being thrown, and reduce their cooldown when cancelled by the plugin
- Implement <https://github.com/Flo56958/MineTinker/projects/3#card-15676822>
- Implement <https://github.com/Flo56958/MineTinker/projects/3#card-15974528>
- Implement conversion of Enchanted Books to Modifier Items
- Fix being able to craft MT Items into MT Items