### PR TITLE
Fix experience bottles and anti arrow plating recipe

### DIFF
--- a/core/src/main/java/de/flo56958/MineTinker/Listeners/EntityListener.java
+++ b/core/src/main/java/de/flo56958/MineTinker/Listeners/EntityListener.java
@@ -127,6 +127,12 @@ public class EntityListener implements Listener {
         Player p = (Player) e.getEntity().getShooter();
         ItemStack tool = p.getInventory().getItemInMainHand();
 
+        // In the check below this, experience bottles are not throwable by default
+        // This is because they're Experienced Modifier Items
+        if (tool.getType() == Material.EXPERIENCE_BOTTLE) {
+            return;
+        }
+
         // This isn't the best detection, if the player has a non modifier in one hand and
         // one in the other, this won't know which was actually thrown.
         // Maybe improve this before release.

--- a/core/src/main/java/de/flo56958/MineTinker/Modifiers/Types/AntiArrowPlating.java
+++ b/core/src/main/java/de/flo56958/MineTinker/Modifiers/Types/AntiArrowPlating.java
@@ -70,9 +70,9 @@ public class AntiArrowPlating extends Modifier {
         config.addDefault(key + ".CompatibleWithAntiBlast", false);
 
         config.addDefault(key + ".Recipe.Enabled", true);
-        config.addDefault(key + ".Recipe.Top", "IMI");
-        config.addDefault(key + ".Recipe.Middle", "MDM");
-        config.addDefault(key + ".Recipe.Bottom", "IMI");
+        config.addDefault(key + ".Recipe.Top", "IAI");
+        config.addDefault(key + ".Recipe.Middle", "ADA");
+        config.addDefault(key + ".Recipe.Bottom", "IAI");
 
         Map<String, String> recipeMaterials = new HashMap<>();
         recipeMaterials.put("I", "IRON_BLOCK");


### PR DESCRIPTION
Fixes an issue where XP bottles can't be thrown.

Fixes an issue where AntiArrowPlating would fail to register its recipe.