### PR TITLE
Armor listener changes

### DIFF
--- a/core/src/main/java/de/flo56958/MineTinker/Listeners/ArmorListener.java
+++ b/core/src/main/java/de/flo56958/MineTinker/Listeners/ArmorListener.java
@@ -22,11 +22,18 @@ import org.bukkit.event.player.PlayerItemDamageEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.projectiles.ProjectileSource;
 
+import java.util.ArrayList;
 import java.util.Random;
 
 public class ArmorListener implements Listener {
 
 	private static final ModManager modManager = ModManager.instance();
+	private static final ArrayList<EntityDamageEvent.DamageCause> blacklistedCauses = new ArrayList<>();
+
+	static {
+		blacklistedCauses.add(EntityDamageEvent.DamageCause.SUICIDE);
+		blacklistedCauses.add(EntityDamageEvent.DamageCause.VOID);
+	}
 
 	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
 	public void onPlayerDamage(EntityDamageEvent event) {
@@ -42,7 +49,7 @@ public class ArmorListener implements Listener {
 			return;
 		}
 
-		if (event.getCause().equals(EntityDamageEvent.DamageCause.SUICIDE) || event.getCause().equals(EntityDamageEvent.DamageCause.VOID)) {
+		if (blacklistedCauses.contains(event.getCause())) {
 			return;
 		}
 


### PR DESCRIPTION
- Combine both entity damage listeners into one
- Change EventHandler priority to HIGHEST
- Create a list of blacklisted DamageCauses and check if the event's cause is in the list

Edit:
I have not tested these changes myself.
The changes were done due to issues with Towny using the wrong priorities.