### PR TITLE
Removing `PLAYER` from `/mt name`

### DIFF
--- a/src/main/java/de/flo56958/minetinker/commands/subs/NameCommand.java
+++ b/src/main/java/de/flo56958/minetinker/commands/subs/NameCommand.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 
 /**
  * Syntax of /mt convert:
- * 		/mt convert {player} [name]
+ * 		/mt convert [name]
  *
  * Legend:
  * 		{ }: not necessary
@@ -31,13 +31,12 @@ public class NameCommand implements SubCommand {
 
 	@Override
 	public boolean onCommand(@NotNull CommandSender sender, @NotNull String[] args) {
-		if (args.length < 2) {
+		if (args.length < 1) {
 			CommandManager.sendError(sender, LanguageManager.getString("Commands.Failure.Cause.InvalidArguments"));
 			return true;
 		}
 
-		Player player = Bukkit.getPlayer(args[1]);
-		if (sender instanceof Player && player == null) player = (Player) sender;
+		Player player = (Player) sender;
 		if (player == null) {
 			CommandManager.sendError(sender, LanguageManager.getString("Commands.Failure.Cause.PlayerMissing"));
 			return true;
@@ -78,19 +77,6 @@ public class NameCommand implements SubCommand {
 	@Override
 	public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull String[] args) {
 		ArrayList<String> result = new ArrayList<>();
-		if (args.length == 2) {
-			for (Player player : Bukkit.getOnlinePlayers()) {
-				result.add(player.getName());
-			}
-			result.add("@a");
-			result.add("@r");
-
-			if (sender instanceof Entity || sender instanceof BlockState) {
-				result.add("@aw");
-				result.add("@p");
-				result.add("@rw");
-			}
-		}
 		return result;
 	}
 
@@ -116,12 +102,11 @@ public class NameCommand implements SubCommand {
 	@Override @NotNull
 	public Map<Integer, List<ArgumentType>> getArgumentsToParse() {
 		Map<Integer, List<ArgumentType>> argumentsToParse = new HashMap<>();
-		argumentsToParse.put(1, Collections.singletonList(ArgumentType.PLAYER));
 		return argumentsToParse;
 	}
 
 	@Override
 	public @NotNull String syntax() {
-		return "/mt name {Player} [Name] ...";
+		return "/mt name [Name] ...";
 	}
 }


### PR DESCRIPTION
Removing the feature of targeting someone with `/mt name` as it causes:
1. Unintended overwrite access to other player's item's name.
1. Also including target player name inside the new name.