### PR TITLE
Support combining items

### DIFF
--- a/contributors.json
+++ b/contributors.json
@@ -73,5 +73,13 @@
     "transifex": "kaekaes",
     "transifex_languages": [ "es_ES" ],
     "other": []
+  },
+  {
+    "github": "X1nto",
+    "discord": "Xinto#9360",
+    "minecraft": "0fc426c8-146d-389c-b3c4-56ff58f54190",
+    "transifex": null,
+    "transifex_languages": [],
+    "other": []
   }
 ]

--- a/src/main/java/de/flo56958/minetinker/commands/subs/AddExpCommand.java
+++ b/src/main/java/de/flo56958/minetinker/commands/subs/AddExpCommand.java
@@ -1,10 +1,10 @@
 package de.flo56958.minetinker.commands.subs;
 
+import de.flo56958.minetinker.api.SubCommand;
 import de.flo56958.minetinker.commands.ArgumentType;
 import de.flo56958.minetinker.commands.CommandManager;
 import de.flo56958.minetinker.modifiers.ModManager;
 import de.flo56958.minetinker.utils.LanguageManager;
-import de.flo56958.minetinker.api.SubCommand;
 import org.bukkit.Bukkit;
 import org.bukkit.block.BlockState;
 import org.bukkit.command.CommandSender;
@@ -70,7 +70,7 @@ public class AddExpCommand implements SubCommand {
 		ModManager modManager = ModManager.instance();
 
 		if (modManager.isToolViable(tool) || modManager.isArmorViable(tool)) {
-			modManager.addExp(player, tool, amount);
+			modManager.addExp(player, tool, amount, true);
 		} else {
 			CommandManager.sendError(sender, LanguageManager.getString("Commands.Failure.Cause.InvalidItem"));
 		}

--- a/src/main/java/de/flo56958/minetinker/commands/subs/AddModifierCommand.java
+++ b/src/main/java/de/flo56958/minetinker/commands/subs/AddModifierCommand.java
@@ -47,7 +47,7 @@ public class AddModifierCommand implements SubCommand {
 							}
 						}
 						for (int i = 0; i < amount; i++) {
-							if (!modManager.addMod(player, tool, m, true, false, true))
+							if (!modManager.addMod(player, tool, m, true, false, true, false))
 								break;
 						}
 					} else {

--- a/src/main/java/de/flo56958/minetinker/commands/subs/RemoveModifierCommand.java
+++ b/src/main/java/de/flo56958/minetinker/commands/subs/RemoveModifierCommand.java
@@ -49,7 +49,7 @@ public class RemoveModifierCommand implements SubCommand {
 						}
 						modManager.removeMod(tool, m);
 						for (int i = 0; i < toAdd; i++) {
-							if (!modManager.addMod(player, tool, m, true, false, true))
+							if (!modManager.addMod(player, tool, m, true, false, true, false))
 								break;
 						}
 					} else

--- a/src/main/java/de/flo56958/minetinker/listeners/AnvilListener.java
+++ b/src/main/java/de/flo56958/minetinker/listeners/AnvilListener.java
@@ -65,29 +65,25 @@ public class AnvilListener implements Listener {
 		}
 
 		if (!modManager.isModifierItem(item2)) { //Upgrade or combining
+			if (!(item1.getType().equals(newTool.getType())
+					&& item1.getType().equals(item2.getType())
+					&& (modManager.isToolViable(item2) || modManager.isArmorViable(item2)))) { //Not Combining
+				if (new Random().nextInt(100) < MineTinker.getPlugin().getConfig().getInt("ChanceToFailToolUpgrade")) {
+					newTool = item1;
+					Bukkit.getPluginManager().callEvent(new ToolUpgradeEvent(player, newTool, false));
+				} else {
+					Bukkit.getPluginManager().callEvent(new ToolUpgradeEvent(player, newTool, true));
+				}
+			}
+
 			if (event.isShiftClick()) {
 				if (player.getInventory().addItem(newTool).size() != 0) { //adds items to (full) inventory and then case if inventory is full
 					event.setCancelled(true); //cancels the event if the player has a full inventory
 					return;
 				} // no else as it gets added in if-clause
-
 				inv.clear();
 				return;
 			}
-
-			if (item1.getType().equals(newTool.getType())) { //Combining
-				player.setItemOnCursor(newTool);
-				inv.clear();
-				return;
-			}
-
-			if (new Random().nextInt(100) < MineTinker.getPlugin().getConfig().getInt("ChanceToFailToolUpgrade")) {
-				newTool = item1;
-				Bukkit.getPluginManager().callEvent(new ToolUpgradeEvent(player, newTool, false));
-			} else {
-				Bukkit.getPluginManager().callEvent(new ToolUpgradeEvent(player, newTool, true));
-			}
-
 			player.setItemOnCursor(newTool);
 			inv.clear();
 		} else { //is modifier

--- a/src/main/java/de/flo56958/minetinker/listeners/AnvilListener.java
+++ b/src/main/java/de/flo56958/minetinker/listeners/AnvilListener.java
@@ -65,6 +65,16 @@ public class AnvilListener implements Listener {
 		}
 
 		if (!modManager.isModifierItem(item2)) { //Upgrade or combining
+			if (event.isShiftClick()) {
+				if (player.getInventory().addItem(newTool).size() != 0) { //adds items to (full) inventory and then case if inventory is full
+					event.setCancelled(true); //cancels the event if the player has a full inventory
+					return;
+				} // no else as it gets added in if-clause
+
+				inv.clear();
+				return;
+			}
+
 			if (item1.getType().equals(newTool.getType())) { //Combining
 				player.setItemOnCursor(newTool);
 				inv.clear();
@@ -76,17 +86,6 @@ public class AnvilListener implements Listener {
 				Bukkit.getPluginManager().callEvent(new ToolUpgradeEvent(player, newTool, false));
 			} else {
 				Bukkit.getPluginManager().callEvent(new ToolUpgradeEvent(player, newTool, true));
-			}
-
-			// ------ upgrade
-			if (event.isShiftClick()) {
-				if (player.getInventory().addItem(newTool).size() != 0) { //adds items to (full) inventory and then case if inventory is full
-					event.setCancelled(true); //cancels the event if the player has a full inventory
-					return;
-				} // no else as it gets added in if-clause
-
-				inv.clear();
-				return;
 			}
 
 			player.setItemOnCursor(newTool);
@@ -178,17 +177,16 @@ public class AnvilListener implements Listener {
 			if (!modManager.addMod(player, newTool, mod, false, false, false, true)) {
 				return;
 			}
-		} else if (item1.getType() == item2.getType()) { //Whether we're combining the tools
-			if (MineTinker.getPlugin().getConfig().getBoolean("Combinable")
+		} else if (item1.getType().equals(item2.getType())) { //Whether we're combining the tools
+			if ((modManager.isToolViable(item2) || modManager.isArmorViable(item2))
+					&& MineTinker.getPlugin().getConfig().getBoolean("Combinable")
 					&& player.hasPermission("minetinker.tool.combine")) {
 				newTool = item1.clone();
 
 				for (Modifier tool2Mod : modManager.getToolMods(item2)) {
 					int modLevel = modManager.getModLevel(item2, tool2Mod);
 					for (int i = 0; i < modLevel; i++) {
-						if (!modManager.addMod(player, newTool, tool2Mod, false, false, true, false)) {
-							return;
-						}
+						modManager.addMod(player, newTool, tool2Mod, false, false, true, false);
 					}
 				}
 

--- a/src/main/java/de/flo56958/minetinker/listeners/AnvilListener.java
+++ b/src/main/java/de/flo56958/minetinker/listeners/AnvilListener.java
@@ -186,7 +186,9 @@ public class AnvilListener implements Listener {
 				for (Modifier tool2Mod : modManager.getToolMods(item2)) {
 					int modLevel = modManager.getModLevel(item2, tool2Mod);
 					for (int i = 0; i < modLevel; i++) {
-						modManager.addMod(player, newTool, tool2Mod, false, false, true, false);
+						if (!modManager.addMod(player, newTool, tool2Mod, false, false, true, false)) {
+							return;
+						}
 					}
 				}
 

--- a/src/main/java/de/flo56958/minetinker/listeners/ArmorListener.java
+++ b/src/main/java/de/flo56958/minetinker/listeners/ArmorListener.java
@@ -140,7 +140,7 @@ public class ArmorListener implements Listener {
 			return;
 		}
 
-		modManager.addExp(player, tool, amount);
+		modManager.addExp(player, tool, amount, true);
 	}
 
 	@EventHandler(ignoreCancelled = true)
@@ -159,7 +159,7 @@ public class ArmorListener implements Listener {
 
 		final int chance = new Random().nextInt(100);
 		if (chance < ConfigurationManager.getConfig("Elytra.yml").getInt("ExpChanceWhileFlying")) {
-			modManager.addExp(event.getPlayer(), event.getItem(), MineTinker.getPlugin().getConfig().getInt("ExpPerEntityHit"));
+			modManager.addExp(event.getPlayer(), event.getItem(), MineTinker.getPlugin().getConfig().getInt("ExpPerEntityHit"), true);
 		}
 	}
 }

--- a/src/main/java/de/flo56958/minetinker/listeners/BlockListener.java
+++ b/src/main/java/de/flo56958/minetinker/listeners/BlockListener.java
@@ -84,7 +84,7 @@ public class BlockListener implements Listener {
 			return;
 		}
 
-		modManager.addExp(player, tool, MineTinker.getPlugin().getConfig().getInt("ExpPerBlockBreak"));
+		modManager.addExp(player, tool, MineTinker.getPlugin().getConfig().getInt("ExpPerBlockBreak"), true);
 
 		Bukkit.getPluginManager().callEvent(new MTPlayerInteractEvent(tool, event));
 	}
@@ -148,7 +148,7 @@ public class BlockListener implements Listener {
 					//adds 0 if not in found in config (negative values are also fine)
 				}
 
-				modManager.addExp(player, tool, expAmount);
+				modManager.addExp(player, tool, expAmount, true);
 			}
 		}
 
@@ -310,7 +310,7 @@ public class BlockListener implements Listener {
 		}
 
 		modManager.addExp(player, tool,
-				MineTinker.getPlugin().getConfig().getInt("ExpPerBlockBreak"));
+				MineTinker.getPlugin().getConfig().getInt("ExpPerBlockBreak"), true);
 		Bukkit.getPluginManager().callEvent(new MTPlayerInteractEvent(tool, event));
 	}
 
@@ -357,7 +357,7 @@ public class BlockListener implements Listener {
 		}
 
 		modManager.addExp(player, tool,
-				MineTinker.getPlugin().getConfig().getInt("ExpPerBlockBreak"));
+				MineTinker.getPlugin().getConfig().getInt("ExpPerBlockBreak"), true);
 
 		Bukkit.getPluginManager().callEvent(new MTPlayerInteractEvent(tool, event));
 	}

--- a/src/main/java/de/flo56958/minetinker/listeners/EnchantingListener.java
+++ b/src/main/java/de/flo56958/minetinker/listeners/EnchantingListener.java
@@ -98,7 +98,7 @@ public class EnchantingListener implements Listener {
 					if (free)
 						modManager.setFreeSlots(event.getItem(), modManager.getFreeSlots(event.getItem()) + modifier.getSlotCost());
 					if (!modManager.addMod(event.getEnchanter(), event.getItem(), modifier,
-							false, false, true)) {
+							false, false, true, true)) {
 						//Remove slots as they were not needed
 						if (free)
 							modManager.setFreeSlots(event.getItem(), modManager.getFreeSlots(event.getItem()) - modifier.getSlotCost());
@@ -164,7 +164,7 @@ public class EnchantingListener implements Listener {
 						if (free)
 							modManager.setFreeSlots(newTool, modManager.getFreeSlots(newTool) + modifier.getSlotCost());
 						if (!modManager.addMod(player, newTool, modifier,
-								false,false, true)) {
+								false,false, true, true)) {
 							//Remove slots as they were not needed
 							if (free)
 								modManager.setFreeSlots(newTool, modManager.getFreeSlots(newTool) - modifier.getSlotCost());

--- a/src/main/java/de/flo56958/minetinker/listeners/EntityListener.java
+++ b/src/main/java/de/flo56958/minetinker/listeners/EntityListener.java
@@ -97,7 +97,7 @@ public class EntityListener implements Listener {
 
 		modManager.addExp(player, tool,
 				MineTinker.getPlugin().getConfig().getInt("ExtraExpPerEntityHit."
-						+ event.getEntity().getType().toString(), 0));
+						+ event.getEntity().getType().toString(), 0), true);
 	}
 
 	@EventHandler
@@ -133,10 +133,10 @@ public class EntityListener implements Listener {
 						final int exp = rand.nextInt(config.getInt("ConvertMobDrops.MaximumNumberOfExp", 650));
 						final int divider = config.getInt("LevelStep", 100);
 						for (int i = 0; i < (exp - 17) / divider; i++) { //to get possible LevelUps
-							modManager.addExp(null, item, divider);
+							modManager.addExp(null, item, divider, true);
 						}
 						final long difference = exp - modManager.getExp(item);
-						modManager.addExp(null, item, difference);
+						modManager.addExp(null, item, difference, true);
 					}
 
 					if (config.getBoolean("ConvertMobDrops.ApplyModifiers", true)) {
@@ -150,7 +150,7 @@ public class EntityListener implements Listener {
 							for (int j = 0; j < 2; j++) { //to give an extra chance
 								final int index = rand.nextInt(mods.size());
 								final Modifier mod = mods.get(index);
-								if (modManager.addMod(player, item, mod, true, true, true)) {
+								if (modManager.addMod(player, item, mod, true, true, true, true)) {
 									if (config.getBoolean("ConvertMobDrops.AppliedModifiersConsiderSlots", true)) {
 										modManager.setFreeSlots(item, modManager.getFreeSlots(item) - 1);
 									}
@@ -184,7 +184,7 @@ public class EntityListener implements Listener {
 		Bukkit.getPluginManager().callEvent(new MTEntityDeathEvent(player, tool, event));
 
 		modManager.addExp(player, tool, MineTinker.getPlugin().getConfig()
-				.getInt("ExtraExpPerEntityDeath." + event.getEntity().getType().toString(), 0));
+				.getInt("ExtraExpPerEntityDeath." + event.getEntity().getType().toString(), 0), true);
 	}
 
 	@EventHandler(ignoreCancelled = true)
@@ -249,7 +249,7 @@ public class EntityListener implements Listener {
 			return;
 		}
 
-		modManager.addExp(player, tool, MineTinker.getPlugin().getConfig().getInt("ExpPerArrowShot"));
+		modManager.addExp(player, tool, MineTinker.getPlugin().getConfig().getInt("ExpPerArrowShot"), true);
 
         /*
         Self-Repair and Experienced will no longer trigger on bowfire

--- a/src/main/java/de/flo56958/minetinker/listeners/PlayerListener.java
+++ b/src/main/java/de/flo56958/minetinker/listeners/PlayerListener.java
@@ -86,7 +86,7 @@ public class PlayerListener implements Listener {
 			if (mod != null) { //shouldn't be necessary
 				while(repair.getAmount() > 0) {
 					if (modManager.addMod((Player) event.getWhoClicked(), tool, mod,
-							false, false, false)) {
+							false, false, false, true)) {
 						//Mod was successful
 						//Decrement item count
 						repair.setAmount(repair.getAmount() - 1);

--- a/src/main/java/de/flo56958/minetinker/listeners/TinkerListener.java
+++ b/src/main/java/de/flo56958/minetinker/listeners/TinkerListener.java
@@ -189,7 +189,7 @@ public class TinkerListener implements Listener {
 										player.getWorld().dropItem(player.getLocation(), mod.getModItem()); //drops item when inventory is full
 									} // no else as it gets added in if
 								} else {
-									appliedRandomMod = modManager.addMod(player, tool, mod, true, true, false);
+									appliedRandomMod = modManager.addMod(player, tool, mod, true, true, false, true);
 								}
 								if (!appliedRandomMod) {
 									mods.remove(index); //Remove the failed modifier from the the list of the possibles

--- a/src/main/java/de/flo56958/minetinker/listeners/TridentListener.java
+++ b/src/main/java/de/flo56958/minetinker/listeners/TridentListener.java
@@ -31,7 +31,7 @@ public class TridentListener implements Listener {
 			return;
 		}
 
-		ModManager.instance().addExp(player, trident, -20000);
+		ModManager.instance().addExp(player, trident, -20000, true);
 		//trident is a item clone and only for triggering modifier effects
 		//this makes sure that the item duplicate does not get any level ups
 		TridentToItemStack.put((Trident) event.getEntity(), trident);

--- a/src/main/java/de/flo56958/minetinker/modifiers/ModManager.java
+++ b/src/main/java/de/flo56958/minetinker/modifiers/ModManager.java
@@ -242,7 +242,7 @@ public class ModManager {
 
 	public List<Modifier> getToolMods(ItemStack tool) {
 		ArrayList<Modifier> mods = new ArrayList<>();
-		for (Modifier mod : getAllMods()) {
+		for (Modifier mod : getAllowedMods()) {
 			if (hasMod(tool, mod)) {
 				mods.add(mod);
 			}

--- a/src/main/java/de/flo56958/minetinker/modifiers/ModManager.java
+++ b/src/main/java/de/flo56958/minetinker/modifiers/ModManager.java
@@ -240,6 +240,16 @@ public class ModManager {
 		};
 	}
 
+	public List<Modifier> getToolMods(ItemStack tool) {
+		ArrayList<Modifier> mods = new ArrayList<>();
+		for (Modifier mod : getAllMods()) {
+			if (hasMod(tool, mod)) {
+				mods.add(mod);
+			}
+		}
+		return mods;
+	}
+
 	public void reload() {
 		config = MineTinker.getPlugin().getConfig();
 		layout = ConfigurationManager.getConfig("layout.yml");
@@ -482,6 +492,17 @@ public class ModManager {
 		Integer tag = DataHandler.getTag(is, mod.getKey(), PersistentDataType.INTEGER, false);
 		if (tag == null) return 0;
 		return tag;
+	}
+
+	/**
+	 * Set the modifier level
+	 * @param is the item
+	 * @param mod the modifier
+	 */
+	public void setModLevel(@Nullable final ItemStack is, @NotNull final Modifier mod, final int level) {
+		if (is == null) return;
+		DataHandler.setTag(is, mod.getKey(), level, PersistentDataType.INTEGER, false);
+		rewriteLore(is);
 	}
 
 	/**

--- a/src/main/java/de/flo56958/minetinker/modifiers/ModManager.java
+++ b/src/main/java/de/flo56958/minetinker/modifiers/ModManager.java
@@ -448,10 +448,10 @@ public class ModManager {
 		rewriteLore(is);
 	}
 
-	public boolean addMod(final Player player, @NotNull final ItemStack item, @NotNull final Modifier modifier, final boolean fromCommand, final boolean fromRandom, final boolean silent) {
+	public boolean addMod(final Player player, @NotNull final ItemStack item, @NotNull final Modifier modifier, final boolean fromCommand, final boolean fromRandom, final boolean silent, final boolean modifySlotCount) {
 		if (!modifier.getKey().equals(ExtraModifier.instance().getKey())) {
 			if (!modifier.checkAndAdd(player, item,
-					modifier.getKey().toLowerCase().replace("-", ""), fromCommand, fromRandom, silent)) {
+					modifier.getKey().toLowerCase().replace("-", ""), fromCommand, fromRandom, silent, modifySlotCount)) {
 				return false;
 			}
 		}
@@ -492,17 +492,6 @@ public class ModManager {
 		Integer tag = DataHandler.getTag(is, mod.getKey(), PersistentDataType.INTEGER, false);
 		if (tag == null) return 0;
 		return tag;
-	}
-
-	/**
-	 * Set the modifier level
-	 * @param is the item
-	 * @param mod the modifier
-	 */
-	public void setModLevel(@Nullable final ItemStack is, @NotNull final Modifier mod, final int level) {
-		if (is == null) return;
-		DataHandler.setTag(is, mod.getKey(), level, PersistentDataType.INTEGER, false);
-		rewriteLore(is);
 	}
 
 	/**
@@ -613,7 +602,7 @@ public class ModManager {
 	 * @param tool   tool that needs to get exp
 	 * @param amount how much exp should the tool get
 	 */
-	public void addExp(@Nullable final Player player, @NotNull final ItemStack tool, final long amount) {
+	public void addExp(@Nullable final Player player, @NotNull final ItemStack tool, final long amount, final boolean callLevelUpEvent) {
 		if (amount == 0) {
 			return;
 		}
@@ -652,7 +641,7 @@ public class ModManager {
 		setExp(tool, exp);
 		rewriteLore(tool);
 
-		if (LevelUp) {
+		if (LevelUp && callLevelUpEvent) {
 			Bukkit.getPluginManager().callEvent(new ToolLevelUpEvent(player, tool));
 		}
 	}

--- a/src/main/java/de/flo56958/minetinker/modifiers/Modifier.java
+++ b/src/main/java/de/flo56958/minetinker/modifiers/Modifier.java
@@ -58,12 +58,14 @@ public abstract class Modifier {
 		this.source = source;
 	}
 
-	boolean checkAndAdd(Player player, ItemStack tool, String permission, boolean isCommand, boolean fromRandom, boolean silent) {
-		//Check for free Slots
-		if ((modManager.getFreeSlots(tool) < this.getSlotCost() && !this.equals(ExtraModifier.instance())) && !isCommand) {
-			if (!silent)
-				pluginManager.callEvent(new ModifierFailEvent(player, tool, this, ModifierFailCause.NO_FREE_SLOTS, false));
-			return false;
+	boolean checkAndAdd(Player player, ItemStack tool, String permission, boolean isCommand, boolean fromRandom, boolean silent, boolean modifySlotCount) {
+		if (modifySlotCount) {
+			//Check for free Slots
+			if ((modManager.getFreeSlots(tool) < this.getSlotCost() && !this.equals(ExtraModifier.instance())) && !isCommand) {
+				if (!silent)
+					pluginManager.callEvent(new ModifierFailEvent(player, tool, this, ModifierFailCause.NO_FREE_SLOTS, false));
+				return false;
+			}
 		}
 
 		//Check for Permission
@@ -124,8 +126,8 @@ public abstract class Modifier {
 
 		modManager.addMod(tool, this);
 
-		//Reduce Slotamount
-		if (!isCommand) {
+		if (modifySlotCount) {
+			//Reduce Slotamount
 			modManager.setFreeSlots(tool, modManager.getFreeSlots(tool) - this.getSlotCost());
 		}
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -51,6 +51,7 @@ AddModifierSlotsPerLevel: 1           #Amount of new free Modifier-Slots for eac
 StartingModifierSlots: 1
 Upgradeable: true                     #Can you upgrade your tools with an anvil
 Repairable: true                      #Can you repair your tools in your inventory (instead of an anvil) just by dragging the ressource on the tool
+Combinable: true                      #Can you combine tools with an anvil to upgrade modifier levels
 ModifiableInInventory: false          #Can you modify tools in the inventory
 UnbreakableTools: true                #Makes sure that tools can not break while using them (will make the tools not useable untill repaired)
 Grindstone:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -30,11 +30,16 @@ permissions:
   minetinker.tool.*:
     children:
       minetinker.tool.create: true
+      minetinker.tool.combine: true
       minetinker.tool.upgrade: true
       minetinker.tool.repair: true
 
   minetinker.tool.create:
     description: Allows to create / craft a MineTinker-Tool
+    default: true
+
+  minetinker.tool.combine:
+    description: Allows to combine MineTinker-Tools
     default: true
 
   minetinker.tool.upgrade:


### PR DESCRIPTION
- Add support for combining items of the same type*.
- Add corresponding configurations and permissions.
- Refactor code a bit for more flexibility:
  - Rename `tool` and `modifier` variables to `item1` and `item2`.
  - Add `modifySlotCount` parameter in addMod, which can be used for applying mods without checking/modifying the current tool slot count.

*Supports combining XP and Modifiers.

closes #114 