### PR TITLE
Adjust anvil combining for tools

### DIFF
--- a/contributors.json
+++ b/contributors.json
@@ -77,7 +77,7 @@
   {
     "github": "X1nto",
     "discord": "Xinto#9360",
-    "minecraft": "0fc426c8-146d-389c-b3c4-56ff58f54190",
+    "minecraft": "c11bbc86-6d3e-4738-b8b1-429187200c47",
     "transifex": null,
     "transifex_languages": [],
     "other": []

--- a/src/main/java/de/flo56958/minetinker/listeners/AnvilListener.java
+++ b/src/main/java/de/flo56958/minetinker/listeners/AnvilListener.java
@@ -180,14 +180,14 @@ public class AnvilListener implements Listener {
 					&& player.hasPermission("minetinker.tool.combine")) {
 				newTool = item1.clone();
 
-				List<Modifier> newToolMods = modManager.getToolMods(newTool);
-				List<Modifier> item2Mods = modManager.getToolMods(item2);
-				var sharedModifiers = item2Mods.stream().filter(newToolMods::contains).toList();
-				var uniqueModifiers = item2Mods.stream().filter(Predicate.not(newToolMods::contains)).toList();
+				final List<Modifier> newToolMods = modManager.getToolMods(newTool);
+				final List<Modifier> item2Mods = modManager.getToolMods(item2);
+				final List<Modifier> sharedModifiers = item2Mods.stream().filter(newToolMods::contains).toList();
+				final List<Modifier> uniqueModifiers = item2Mods.stream().filter(Predicate.not(newToolMods::contains)).toList();
 
 				for (var shared : sharedModifiers) {
-					var newToolModLevel = modManager.getModLevel(newTool, shared);
-					var item2ModLevel = modManager.getModLevel(item2, shared);
+					final int newToolModLevel = modManager.getModLevel(newTool, shared);
+					final int item2ModLevel = modManager.getModLevel(item2, shared);
 
 					int iterations = 0;
 					if (item2ModLevel > newToolModLevel) { //If the 2nd tool's modifier has a higher level, clamp the level to the 2nd tool's level.
@@ -201,7 +201,7 @@ public class AnvilListener implements Listener {
 				}
 
 				for (Modifier unique : uniqueModifiers) {
-					int modLevel = modManager.getModLevel(item2, unique);
+					final int modLevel = modManager.getModLevel(item2, unique);
 					for (int i = 0; i < modLevel; i++) {
 						modManager.addMod(player, newTool, unique, false, false, true, false);
 					}

--- a/src/main/java/de/flo56958/minetinker/listeners/AnvilListener.java
+++ b/src/main/java/de/flo56958/minetinker/listeners/AnvilListener.java
@@ -189,13 +189,11 @@ public class AnvilListener implements Listener {
 					final int newToolModLevel = modManager.getModLevel(newTool, shared);
 					final int item2ModLevel = modManager.getModLevel(item2, shared);
 
-					int iterations = 0;
 					if (item2ModLevel > newToolModLevel) { //If the 2nd tool's modifier has a higher level, clamp the level to the 2nd tool's level.
-						iterations = item2ModLevel - newToolModLevel;
+						for (int i = 0; i < item2ModLevel - newToolModLevel; i++) {
+							modManager.addMod(player, newTool, shared, false, false, true, false);
+						}
 					} else if (item2ModLevel == newToolModLevel) {
-						iterations = 1;
-					}
-					for (int i = 0; i < iterations; i++) {
 						modManager.addMod(player, newTool, shared, false, false, true, false);
 					}
 				}

--- a/src/main/java/de/flo56958/minetinker/listeners/AnvilListener.java
+++ b/src/main/java/de/flo56958/minetinker/listeners/AnvilListener.java
@@ -182,10 +182,11 @@ public class AnvilListener implements Listener {
 
 				final List<Modifier> newToolMods = modManager.getToolMods(newTool);
 				final List<Modifier> item2Mods = modManager.getToolMods(item2);
+
 				final List<Modifier> sharedModifiers = item2Mods.stream().filter(newToolMods::contains).toList();
 				final List<Modifier> uniqueModifiers = item2Mods.stream().filter(Predicate.not(newToolMods::contains)).toList();
 
-				for (var shared : sharedModifiers) {
+				for (Modifier shared : sharedModifiers) {
 					final int newToolModLevel = modManager.getModLevel(newTool, shared);
 					final int item2ModLevel = modManager.getModLevel(item2, shared);
 


### PR DESCRIPTION
In vanilla Minecraft, when combining tools/armor with the same enchants, the level of the enchantment in the combined item is produced with this formula:
  - If the levels are the same on both the first and the second item, the combined item will have the enchantment level of [the level that both items have] + 1. i.e: if we have 2 iron chestplates with protection 2 on both of them, combining those will give us an iron chestplate with protection 3.
  - If levels are different, the combined item will have the highest level of the 2 provided items. i.e: if we have 2 diamond boots with protection 1 and 2, the combined boots will have protection 2.

This PR ensures the same happens in Minetinker when combining tools with the same enchantments.